### PR TITLE
Subclassing FuCrosEcUsbHammer from FuCrosEcUsbDevice

### DIFF
--- a/plugins/cros-ec/cros-ec.quirk
+++ b/plugins/cros-ec/cros-ec.quirk
@@ -27,3 +27,9 @@ Summary = Belkin Reference Board
 [USB\VID_18D1&PID_5022]
 Plugin = cros_ec
 Summary = Prism Board
+
+# Hammer
+[USB\VID_18D1&PID_5061]
+Plugin = cros_ec
+Summary = Hammer Base Detachable
+Flags = has-touchpad

--- a/plugins/cros-ec/cros-ec.quirk
+++ b/plugins/cros-ec/cros-ec.quirk
@@ -2,34 +2,42 @@
 [USB\VID_18D1&PID_501A]
 Plugin = cros_ec
 Summary = Servo Micro (aka "uServo") Debug Board
+GType = FuCrosEcUsbDevice
 
 # Quiche
 [USB\VID_18D1&PID_5048]
 Plugin = cros_ec
 Summary = Quiche Reference Board
+GType = FuCrosEcUsbDevice
 
 # Baklava (D501)
 [USB\VID_0502&PID_1195]
 Plugin = cros_ec
 Summary = D501 Device (Google Quiche derivative)
+GType = FuCrosEcUsbDevice
 
 # Gingerbread
 [USB\VID_18D1&PID_5049]
 Plugin = cros_ec
 Summary = Gingerbread Reference Board
+GType = FuCrosEcUsbDevice
+
 
 # Belkin
 [USB\VID_050D&PID_003F]
 Plugin = cros_ec
 Summary = Belkin Reference Board
+GType = FuCrosEcUsbDevice
 
 # Prism
 [USB\VID_18D1&PID_5022]
 Plugin = cros_ec
 Summary = Prism Board
+GType = FuCrosEcUsbDevice
 
 # Hammer
 [USB\VID_18D1&PID_5061]
 Plugin = cros_ec
 Summary = Hammer Base Detachable
 Flags = has-touchpad
+GType = FuCrosEcUsbHammer

--- a/plugins/cros-ec/fu-cros-ec-common.h
+++ b/plugins/cros-ec/fu-cros-ec-common.h
@@ -8,6 +8,15 @@
 
 #include <fwupdplugin.h>
 
+#define FU_CROS_EC_MAX_BLOCK_XFER_RETRIES  10
+#define FU_CROS_EC_FLUSH_TIMEOUT_MS	   10
+#define FU_CROS_EC_BULK_SEND_TIMEOUT	   2000 /* ms */
+#define FU_CROS_EC_BULK_RECV_TIMEOUT	   5000 /* ms */
+#define FU_CROS_EC_USB_DEVICE_REMOVE_DELAY 20000
+
+#define FU_CROS_EC_REQUEST_UPDATE_DONE	    0xB007AB1E
+#define FU_CROS_EC_REQUEST_UPDATE_EXTRA_CMD 0xB007AB1F
+
 typedef struct {
 	gchar *boardname;
 	gchar *triplet;

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.c
@@ -23,18 +23,8 @@ fu_cros_ec_hammer_touchpad_firmware_init(FuCrosEcHammerTouchpadFirmware *self)
 }
 
 static void
-fu_cros_ec_hammer_touchpad_firmware_finalize(GObject *object)
-{
-	FuCrosEcHammerTouchpadFirmware *self = FU_CROS_EC_HAMMER_TOUCHPAD_FIRMWARE(object);
-	FuFirmware *test = FU_FIRMWARE(object);
-	G_OBJECT_CLASS(fu_cros_ec_hammer_touchpad_firmware_parent_class)->finalize(object);
-}
-
-static void
 fu_cros_ec_hammer_touchpad_firmware_class_init(FuCrosEcHammerTouchpadFirmwareClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->finalize = fu_cros_ec_hammer_touchpad_firmware_finalize;
 }
 
 FuFirmware *

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Hamed Elgizery
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-cros-ec-common.h"
+#include "fu-cros-ec-firmware.h"
+#include "fu-cros-ec-hammer-touchpad-firmware.h"
+
+struct _FuCrosEcHammerTouchpadFirmware {
+	FuFirmware parent_instance;
+};
+
+G_DEFINE_TYPE(FuCrosEcHammerTouchpadFirmware, fu_cros_ec_hammer_touchpad_firmware, FU_TYPE_FIRMWARE)
+
+gboolean
+fu_cros_ec_hammer_touchpad_firmware_validate_checksum(FuCrosEcHammerTouchpadFirmware *self,
+						      GError **error)
+{
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_cros_ec_hammer_touchpad_firmware_init(FuCrosEcHammerTouchpadFirmware *self)
+{
+}
+
+static void
+fu_cros_ec_hammer_touchpad_firmware_finalize(GObject *object)
+{
+	FuCrosEcFirmware *self = FU_CROS_EC_FIRMWARE(object);
+	G_OBJECT_CLASS(fu_cros_ec_hammer_touchpad_firmware_parent_class)->finalize(object);
+}
+
+static void
+fu_cros_ec_hammer_touchpad_firmware_class_init(FuCrosEcHammerTouchpadFirmwareClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_cros_ec_hammer_touchpad_firmware_finalize;
+}
+
+FuFirmware *
+fu_cros_ec_hammer_touchpad_firmware_new(void)
+{
+	return g_object_new(FU_TYPE_CROS_EC_HAMMER_TOUCHPAD_FIRMWARE, NULL);
+}

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.c
@@ -9,20 +9,13 @@
 #include "fu-cros-ec-common.h"
 #include "fu-cros-ec-firmware.h"
 #include "fu-cros-ec-hammer-touchpad-firmware.h"
+#include "fu-cros-ec-hammer-touchpad.h"
 
 struct _FuCrosEcHammerTouchpadFirmware {
 	FuFirmware parent_instance;
 };
 
 G_DEFINE_TYPE(FuCrosEcHammerTouchpadFirmware, fu_cros_ec_hammer_touchpad_firmware, FU_TYPE_FIRMWARE)
-
-gboolean
-fu_cros_ec_hammer_touchpad_firmware_validate_checksum(FuCrosEcHammerTouchpadFirmware *self,
-						      GError **error)
-{
-	/* success */
-	return TRUE;
-}
 
 static void
 fu_cros_ec_hammer_touchpad_firmware_init(FuCrosEcHammerTouchpadFirmware *self)
@@ -32,7 +25,8 @@ fu_cros_ec_hammer_touchpad_firmware_init(FuCrosEcHammerTouchpadFirmware *self)
 static void
 fu_cros_ec_hammer_touchpad_firmware_finalize(GObject *object)
 {
-	FuCrosEcFirmware *self = FU_CROS_EC_FIRMWARE(object);
+	FuCrosEcHammerTouchpadFirmware *self = FU_CROS_EC_HAMMER_TOUCHPAD_FIRMWARE(object);
+	FuFirmware *test = FU_FIRMWARE(object);
 	G_OBJECT_CLASS(fu_cros_ec_hammer_touchpad_firmware_parent_class)->finalize(object);
 }
 

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.h
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Hamed Elgizery
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#include "fu-cros-ec-common.h"
+#include "fu-cros-ec-struct.h"
+
+#define FU_TYPE_CROS_EC_HAMMER_TOUCHPAD_FIRMWARE (fu_cros_ec_hammer_touchpad_firmware_get_type())
+G_DECLARE_FINAL_TYPE(FuCrosEcHammerTouchpadFirmware,
+		     fu_cros_ec_hammer_touchpad_firmware,
+		     FU,
+		     CROS_EC_HAMMER_TOUCHPAD_FIRMWARE,
+		     FuFirmware)
+
+gboolean
+fu_cros_ec_hammer_touchpad_firmware_validate_checksum(FuCrosEcHammerTouchpadFirmware *self,
+						      GError **error);
+FuFirmware *
+fu_cros_ec_hammer_touchpad_firmware_new(void);

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.h
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.h
@@ -18,9 +18,5 @@ G_DECLARE_FINAL_TYPE(FuCrosEcHammerTouchpadFirmware,
 		     CROS_EC_HAMMER_TOUCHPAD_FIRMWARE,
 		     FuFirmware)
 
-gboolean
-fu_cros_ec_hammer_touchpad_firmware_validate_checksum(FuDevice *device,
-						      FuCrosEcHammerTouchpadFirmware *self,
-						      GError **error);
 FuFirmware *
 fu_cros_ec_hammer_touchpad_firmware_new(void);

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.h
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad-firmware.h
@@ -19,7 +19,8 @@ G_DECLARE_FINAL_TYPE(FuCrosEcHammerTouchpadFirmware,
 		     FuFirmware)
 
 gboolean
-fu_cros_ec_hammer_touchpad_firmware_validate_checksum(FuCrosEcHammerTouchpadFirmware *self,
+fu_cros_ec_hammer_touchpad_firmware_validate_checksum(FuDevice *device,
+						      FuCrosEcHammerTouchpadFirmware *self,
 						      GError **error);
 FuFirmware *
 fu_cros_ec_hammer_touchpad_firmware_new(void);

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -136,12 +136,25 @@ fu_cros_ec_hammer_touchpad_init(FuCrosEcHammerTouchpad *self)
 }
 
 static void
+fu_cros_ec_hammer_touchpad_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(device);
+	// TODO: Retake a look on what is important
+	fwupd_codec_string_append_int(str, idt, "Vendor", self->vendor);
+	fwupd_codec_string_append_hex(str, idt, "FwAddress", self->fw_address);
+	fwupd_codec_string_append_int(str, idt, "FwSize", self->fw_size);
+	fwupd_codec_string_append(str, idt, "AllowedFwHash", self->allowed_fw_hash);
+	fwupd_codec_string_append_int(str, idt, "RawVersion", self->fw_version);
+}
+
+static void
 fu_cros_ec_hammer_touchpad_class_init(FuCrosEcHammerTouchpadClass *klass)
 {
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_cros_ec_hammer_touchpad_finalize;
 	device_class->setup = fu_cros_ec_hammer_touchpad_setup;
+	device_class->to_string = fu_cros_ec_hammer_touchpad_to_string;
 }
 
 FuCrosEcHammerTouchpad *

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -115,10 +115,7 @@ fu_cros_ec_hammer_touchpad_get_info(FuCrosEcHammerTouchpad *self, GError **error
 						   &response_size,
 						   FALSE,
 						   &error_local)) {
-		g_prefix_error(error,
-			       FWUPD_ERROR,
-			       FWUPD_ERROR_INVALID_DATA,
-			       "failed to probe touchpad");
+		g_prefix_error(error, "failed to probe touchpad");
 		return FALSE;
 	}
 

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -41,14 +41,18 @@ fu_cros_ec_hammer_touchpad_set_metadata(FuCrosEcHammerTouchpad *self, GError **e
 	case ST_VENDOR_ID:
 		base_fw_ver = g_strdup_printf("%d.%d",
 					      self->fw_version & 0x00ff,
-					      (self->fw_version & 0xff00) >> 8); // TODO: Fix
-		vendor_name = g_strdup("ST");
+					      (self->fw_version & 0xff00) >> 8);
+		vendor_name = g_strdup("STMicroelectronics");
 		break;
 	case ELAN_VENDOR_ID:
 		base_fw_ver = g_strdup_printf("%d.0", self->fw_version);
 		vendor_name = g_strdup("ELAN");
 		break;
 	default:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "invalid touchpad vendor id received");
 		return FALSE;
 	}
 	device_name = g_strdup_printf("%s Touchpad", vendor_name);
@@ -88,8 +92,13 @@ fu_cros_ec_hammer_touchpad_get_info(FuCrosEcHammerTouchpad *self, GError **error
 						   response,
 						   &response_size,
 						   FALSE,
-						   &error_local))
+						   &error_local)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "failed to probe touchpad");
 		return FALSE;
+	}
 
 	error_code = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_status(tpi_rpdu);
 	if (error_code != 0) {

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -38,9 +38,11 @@ fu_cros_ec_hammer_touchpad_set_version(FuCrosEcHammerTouchpad *self, GError **er
 		base_fw_ver = g_strdup_printf("%d.%d",
 					      self->fw_version & 0x00ff,
 					      (self->fw_version & 0xff00) >> 8); // TODO: Fix
+		fu_device_set_name(FU_DEVICE(self), "ST Touchpad");
 		break;
 	case ELAN_VENDOR_ID:
 		base_fw_ver = g_strdup_printf("%d.0", self->fw_version);
+		fu_device_set_name(FU_DEVICE(self), "ELAN Touchpad");
 		break;
 	default:
 		return FALSE;
@@ -166,7 +168,6 @@ fu_cros_ec_hammer_touchpad_new(FuDevice *parent)
 
 	self = g_object_new(FU_TYPE_CROS_EC_HAMMER_TOUCHPAD, "context", ctx, NULL);
 	fu_device_incorporate(FU_DEVICE(self), parent, FU_DEVICE_INCORPORATE_FLAG_PHYSICAL_ID);
-	fu_device_set_name(FU_DEVICE(self), "Hammer Touchpad");
 	fu_device_set_logical_id(FU_DEVICE(self), "cros-ec-hammer-touchpad");
 	instance_id = g_strdup_printf("USB\\VID_%04X&PID_%04X&TOUCHPAD",
 				      fu_device_get_vid(FU_DEVICE(parent)),

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -190,7 +190,7 @@ fu_cros_ec_hammer_touchpad_firmware_validate(FuDevice *device, FuFirmware *firmw
 	gsize fwsize;
 	const guchar *fw = NULL;
 	GChecksum *checksum = NULL;
-	guint8 digest[SHA256_DIGEST_LENGTH];
+	guint8 digest[SHA256_DIGEST_LENGTH] = {0x0};
 	gsize digest_len = sizeof(digest);
 
 	payload = fu_firmware_get_bytes(firmware, error);

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -1,0 +1,78 @@
+#include "config.h"
+
+#include <string.h>
+
+#include "fu-cros-ec-common.h"
+#include "fu-cros-ec-hammer-touchpad.h"
+#include "fu-cros-ec-usb-device.h"
+
+struct _FuCrosEcHammerTouchpad {
+	FuDevice parent_instance;
+	gchar *raw_version;
+};
+
+G_DEFINE_TYPE(FuCrosEcHammerTouchpad, fu_cros_ec_hammer_touchpad, FU_TYPE_DEVICE)
+
+static gboolean
+fu_cros_ec_hammer_touchpad_setup(FuDevice *device, GError **error)
+{
+	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(device);
+	guint32 error_code;
+	fu_device_set_version(FU_DEVICE(device), "1.1.1");
+	return TRUE;
+}
+
+static void
+fu_cros_ec_hammer_touchpad_finalize(GObject *object)
+{
+	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(object);
+	g_free(self->raw_version);
+	G_OBJECT_CLASS(fu_cros_ec_hammer_touchpad_parent_class)->finalize(object);
+}
+
+static void
+fu_cros_ec_hammer_touchpad_init(FuCrosEcHammerTouchpad *self)
+{
+	fu_device_add_protocol(FU_DEVICE(self), "com.google.usb.crosec");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_DETACH_PREPARE_FIRMWARE);
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+	// fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_CROS_EC_FIRMWARE);
+}
+
+static void
+fu_cros_ec_hammer_touchpad_class_init(FuCrosEcHammerTouchpadClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_cros_ec_hammer_touchpad_finalize;
+	// device_class->prepare_firmware = fu_cros_ec_usb_device_prepare_firmware;
+	device_class->setup = fu_cros_ec_hammer_touchpad_setup;
+	// device_class->to_string = fu_cros_ec_usb_device_to_string;
+	// device_class->write_firmware = fu_cros_ec_usb_device_write_firmware;
+	// device_class->probe = fu_cros_ec_usb_device_probe;
+	// device_class->set_progress = fu_cros_ec_usb_device_set_progress;
+	// device_class->reload = fu_cros_ec_usb_device_reload;
+	// device_class->replace = fu_cros_ec_usb_device_replace;
+	// device_class->cleanup = fu_cros_ec_usb_device_cleanup;
+}
+
+FuCrosEcHammerTouchpad *
+fu_cros_ec_hammer_touchpad_new(FuDevice *parent)
+{
+	FuCrosEcHammerTouchpad *self = NULL;
+	FuContext *ctx = fu_device_get_context(parent);
+	g_autofree gchar *instance_id = NULL;
+
+	self = g_object_new(FU_TYPE_CROS_EC_HAMMER_TOUCHPAD, "context", ctx, NULL);
+	fu_device_incorporate(FU_DEVICE(self), parent, FU_DEVICE_INCORPORATE_FLAG_PHYSICAL_ID);
+	fu_device_set_name(FU_DEVICE(self), "Hammer Touchpad");
+	fu_device_set_logical_id(FU_DEVICE(self), "cros-ec-hammer-touchpad");
+	instance_id = g_strdup_printf("USB\\VID_%04X&PID_%04X&TOUCHPAD",
+				      fu_device_get_vid(FU_DEVICE(parent)),
+				      fu_device_get_pid(FU_DEVICE(parent)));
+	fu_device_add_instance_id(FU_DEVICE(self), instance_id);
+	return self;
+}

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -287,8 +287,8 @@ fu_cros_ec_hammer_touchpad_write_firmware(FuDevice *device,
 					  GError **error)
 {
 	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(device);
-	FuCrosEcHammerTouchpadPrivate *priv = GET_PRIVATE(device);
-	FuDevice *parent = fu_device_get_parent(FU_DEVICE(self));
+	FuCrosEcHammerTouchpadPrivate *priv = GET_PRIVATE(self);
+	FuDevice *parent = fu_device_get_parent(device);
 
 	/*
 	 * Update is done through the parent device (the EC base),

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -19,8 +19,7 @@
 #define ST_VENDOR_ID   0x0483
 #define ELAN_VENDOR_ID 0x04f3
 
-struct _FuCrosEcHammerTouchpad {
-	FuDevice parent_instance;
+typedef struct {
 	guint16 vendor;
 	guint32 fw_address;
 	guint32 fw_size;
@@ -28,19 +27,35 @@ struct _FuCrosEcHammerTouchpad {
 	guint16 id;
 	guint16 fw_version;
 	guint16 fw_checksum;
-};
+} FuCrosEcHammerTouchpadPrivate;
 
-G_DEFINE_TYPE(FuCrosEcHammerTouchpad, fu_cros_ec_hammer_touchpad, FU_TYPE_DEVICE)
+G_DEFINE_TYPE_WITH_PRIVATE(FuCrosEcHammerTouchpad, fu_cros_ec_hammer_touchpad, FU_TYPE_DEVICE)
+#define GET_PRIVATE(o) (fu_cros_ec_hammer_touchpad_get_instance_private(o))
+
+guint32
+fu_cros_ec_hammer_touchpad_get_fw_address(FuCrosEcHammerTouchpad *self)
+{
+	FuCrosEcHammerTouchpadPrivate *priv = GET_PRIVATE(self);
+	return priv->fw_address;
+}
+
+guint32
+fu_cros_ec_hammer_touchpad_get_fw_size(FuCrosEcHammerTouchpad *self)
+{
+	FuCrosEcHammerTouchpadPrivate *priv = GET_PRIVATE(self);
+	return priv->fw_size;
+}
 
 static gboolean
 fu_cros_ec_hammer_touchpad_set_metadata(FuCrosEcHammerTouchpad *self, GError **error)
 {
+	FuCrosEcHammerTouchpadPrivate *priv = GET_PRIVATE(self);
 	FuDevice *parent = fu_device_get_parent(FU_DEVICE(self));
 	gchar *base_fw_ver;
 	g_autofree gchar *instance_id = NULL;
 	g_autofree gchar *vendor_name = NULL;
 	g_autofree gchar *device_name = NULL;
-	switch (self->vendor) {
+	switch (priv->vendor) {
 	case ST_VENDOR_ID:
 		base_fw_ver = g_strdup_printf("%d.%d",
 					      self->fw_version & 0x00ff,
@@ -48,7 +63,7 @@ fu_cros_ec_hammer_touchpad_set_metadata(FuCrosEcHammerTouchpad *self, GError **e
 		vendor_name = g_strdup("STMicroelectronics");
 		break;
 	case ELAN_VENDOR_ID:
-		base_fw_ver = g_strdup_printf("%d.0", self->fw_version);
+		base_fw_ver = g_strdup_printf("%d.0", priv->fw_version);
 		vendor_name = g_strdup("ELAN");
 		break;
 	default:
@@ -74,6 +89,7 @@ fu_cros_ec_hammer_touchpad_set_metadata(FuCrosEcHammerTouchpad *self, GError **e
 static gboolean
 fu_cros_ec_hammer_touchpad_get_info(FuCrosEcHammerTouchpad *self, GError **error)
 {
+	FuCrosEcHammerTouchpadPrivate *priv = GET_PRIVATE(self);
 	FuDevice *parent = fu_device_get_parent(FU_DEVICE(self));
 	gsize bufsz;
 	guint32 error_code;
@@ -113,16 +129,16 @@ fu_cros_ec_hammer_touchpad_get_info(FuCrosEcHammerTouchpad *self, GError **error
 		return FALSE;
 	}
 
-	self->vendor = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_vendor(tpi_rpdu);
-	self->fw_address =
+	priv->vendor = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_vendor(tpi_rpdu);
+	priv->fw_address =
 	    fu_struct_cros_ec_touchpad_get_info_response_pdu_get_fw_address(tpi_rpdu);
-	self->fw_size = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_fw_size(tpi_rpdu);
-	self->allowed_fw_hash =
+	priv->fw_size = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_fw_size(tpi_rpdu);
+	priv->allowed_fw_hash =
 	    fu_struct_cros_ec_touchpad_get_info_response_pdu_get_allowed_fw_hash(tpi_rpdu, &bufsz);
-	self->id = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_id(tpi_rpdu);
-	self->fw_version =
+	priv->id = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_id(tpi_rpdu);
+	priv->fw_version =
 	    fu_struct_cros_ec_touchpad_get_info_response_pdu_get_fw_version(tpi_rpdu);
-	self->fw_checksum =
+	priv->fw_checksum =
 	    fu_struct_cros_ec_touchpad_get_info_response_pdu_get_fw_checksum(tpi_rpdu);
 	fu_cros_ec_hammer_touchpad_set_metadata(self, error);
 
@@ -146,23 +162,25 @@ gboolean
 fu_cros_ec_hammer_touchpad_firmware_validate(FuDevice *device, FuFirmware *firmware, GError **error)
 {
 	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(device);
+	FuCrosEcHammerTouchpadPrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GError) error_local = NULL;
 	GBytes *payload = NULL;
 	gsize fwsize;
 	gchar *fw = NULL;
-	;
 
 	payload = fu_firmware_get_bytes(firmware, error);
 	fw = g_bytes_get_data(payload, &fwsize);
 
-	if (self->fw_size != fwsize)
+	if (priv->fw_size != fwsize)
 		return FALSE;
-	g_info("Sizes Matches!");
+	g_debug("Sizes Matches");
 
 	gchar *digest = g_compute_checksum_for_data(G_CHECKSUM_SHA256, fw, fwsize);
-	if (g_strcmp0(digest, self->allowed_fw_hash) != 0)
+	if (g_strcmp0(digest, priv->allowed_fw_hash) != 0)
 		return FALSE;
-	g_info("Checksum Matches!");
+	g_debug("Checksum Matches");
+
+	// TODO: Check product if product id matches
 
 	return FALSE; // Set to false to prevent updating
 }
@@ -177,8 +195,17 @@ fu_cros_ec_hammer_touchpad_prepare_firmware(FuDevice *device,
 	FuCrosEcHammerTouchpad *self = FU_CROS_EC_USB_DEVICE(device);
 	g_autoptr(FuFirmware) firmware = fu_cros_ec_hammer_touchpad_firmware_new();
 
+	// Touchpad is normally updated after the EC is updated,
+	// each EC firmware expects a certain touchpad firmware.
+	// So, before we start updating the touchpad, we need to make
+	// sure it matches the EC expected touchpad firmware. We do that
+	// by querying the EC board for info (that includes the touchpad firmware allowed hash).
+	if (!fu_cros_ec_hammer_touchpad_get_info(FU_CROS_EC_HAMMER_TOUCHPAD(device), error))
+		return NULL;
+
 	if (!fu_firmware_parse_stream(firmware, stream, 0x0, flags, error))
 		return NULL;
+
 	if (!fu_cros_ec_hammer_touchpad_firmware_validate(device, firmware, error))
 		return NULL;
 
@@ -189,7 +216,8 @@ static void
 fu_cros_ec_hammer_touchpad_finalize(GObject *object)
 {
 	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(object);
-	g_free(self->allowed_fw_hash);
+	FuCrosEcHammerTouchpadPrivate *priv = GET_PRIVATE(self);
+	g_free(priv->allowed_fw_hash);
 	G_OBJECT_CLASS(fu_cros_ec_hammer_touchpad_parent_class)->finalize(object);
 }
 
@@ -200,6 +228,7 @@ fu_cros_ec_hammer_touchpad_init(FuCrosEcHammerTouchpad *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_DETACH_PREPARE_FIRMWARE);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_INSTALL_PARENT_FIRST);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 }
@@ -208,12 +237,13 @@ static void
 fu_cros_ec_hammer_touchpad_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(device);
+	FuCrosEcHammerTouchpadPrivate *priv = GET_PRIVATE(self);
 	// TODO: Retake a look on what is important
-	fwupd_codec_string_append_int(str, idt, "Vendor", self->vendor);
-	fwupd_codec_string_append_hex(str, idt, "FwAddress", self->fw_address);
-	fwupd_codec_string_append_int(str, idt, "FwSize", self->fw_size);
-	fwupd_codec_string_append(str, idt, "AllowedFwHash", self->allowed_fw_hash);
-	fwupd_codec_string_append_int(str, idt, "RawVersion", self->fw_version);
+	fwupd_codec_string_append_int(str, idt, "Vendor", priv->vendor);
+	fwupd_codec_string_append_hex(str, idt, "FwAddress", priv->fw_address);
+	fwupd_codec_string_append_int(str, idt, "FwSize", priv->fw_size);
+	fwupd_codec_string_append(str, idt, "AllowedFwHash", priv->allowed_fw_hash);
+	fwupd_codec_string_append_int(str, idt, "RawVersion", priv->fw_version);
 }
 
 static void

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -212,6 +212,30 @@ fu_cros_ec_hammer_touchpad_prepare_firmware(FuDevice *device,
 	return g_steal_pointer(&firmware);
 }
 
+static gboolean
+fu_cros_ec_hammer_touchpad_write_firmware(FuDevice *device,
+					  FuFirmware *firmware,
+					  FuProgress *progress,
+					  FwupdInstallFlags flags,
+					  GError **error)
+{
+	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(device);
+	FuDevice *parent = fu_device_get_parent(FU_DEVICE(self));
+
+	// Update is done through the parent device aka. the EC board,
+	// so we call this and it the EC will handle the updatng.
+	if (!fu_cros_ec_usb_device_write_touchpad_firmware(parent,
+							   firmware,
+							   progress,
+							   flags,
+							   self,
+							   error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
 static void
 fu_cros_ec_hammer_touchpad_finalize(GObject *object)
 {
@@ -255,6 +279,7 @@ fu_cros_ec_hammer_touchpad_class_init(FuCrosEcHammerTouchpadClass *klass)
 	device_class->setup = fu_cros_ec_hammer_touchpad_setup;
 	device_class->to_string = fu_cros_ec_hammer_touchpad_to_string;
 	device_class->prepare_firmware = fu_cros_ec_hammer_touchpad_prepare_firmware;
+	device_class->write_firmware = fu_cros_ec_hammer_touchpad_write_firmware;
 }
 
 FuCrosEcHammerTouchpad *

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -13,6 +13,7 @@
 #include "fu-cros-ec-hammer-touchpad.h"
 #include "fu-cros-ec-struct.h"
 #include "fu-cros-ec-usb-device.h"
+#include "fu-cros-ec-usb-hammer.h"
 
 #define SHA256_DIGEST_LENGTH 32
 
@@ -166,7 +167,7 @@ fu_cros_ec_hammer_touchpad_probe(FuDevice *device, GError **error)
 				      fu_device_get_pid(FU_DEVICE(proxy)));
 	fu_device_add_instance_id(FU_DEVICE(self), instance_id);
 
-	if (fu_cros_ec_usb_device_get_in_bootloader(proxy)) {
+	if (fu_cros_ec_usb_device_get_in_bootloader(FU_CROS_EC_USB_DEVICE(proxy))) {
 		g_debug("skipping enumeration: ec is in bootloader mode");
 		return TRUE;
 	}
@@ -304,7 +305,7 @@ fu_cros_ec_hammer_touchpad_write_firmware(FuDevice *device,
 		return FALSE;
 	}
 
-	if (!fu_cros_ec_usb_device_write_touchpad_firmware(parent,
+	if (!fu_cros_ec_usb_hammer_write_touchpad_firmware(parent,
 							   firmware,
 							   progress,
 							   flags,

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -128,7 +128,6 @@ fu_cros_ec_hammer_touchpad_get_info(FuCrosEcHammerTouchpad *self, GError **error
 			    error_code);
 		return FALSE;
 	}
-	g_warning("(DEBUG) RECEIVED TOUCHPAD INFO");
 
 	priv->vendor = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_vendor(tpi_rpdu);
 	priv->fw_address =
@@ -168,7 +167,7 @@ fu_cros_ec_hammer_touchpad_probe(FuDevice *device, GError **error)
 	fu_device_add_instance_id(FU_DEVICE(self), instance_id);
 
 	if (fu_cros_ec_usb_device_get_in_bootloader(proxy)) {
-		g_warning("(DEBUG) IN BOOTLOADER NOW! SKIP...");
+		g_debug("skipping enumeration: ec is in bootloader mode");
 		return TRUE;
 	}
 

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -1,24 +1,118 @@
+/*
+ * Copyright 2025 Hamed Elgizery
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
 #include "config.h"
 
 #include <string.h>
 
 #include "fu-cros-ec-common.h"
 #include "fu-cros-ec-hammer-touchpad.h"
+#include "fu-cros-ec-struct.h"
 #include "fu-cros-ec-usb-device.h"
+
+#define ST_VENDOR_ID   0x0483
+#define ELAN_VENDOR_ID 0x04f3
 
 struct _FuCrosEcHammerTouchpad {
 	FuDevice parent_instance;
-	gchar *raw_version;
+	guint16 vendor;
+	guint32 fw_address;
+	guint32 fw_size;
+	gchar *allowed_fw_hash;
+	guint16 id;
+	guint16 fw_version;
+	guint16 fw_checksum;
 };
 
 G_DEFINE_TYPE(FuCrosEcHammerTouchpad, fu_cros_ec_hammer_touchpad, FU_TYPE_DEVICE)
 
 static gboolean
+fu_cros_ec_hammer_touchpad_set_version(FuCrosEcHammerTouchpad *self, GError **error)
+{
+	gchar *base_fw_ver;
+	switch (self->vendor) {
+	case ST_VENDOR_ID:
+		base_fw_ver = g_strdup_printf("%d.%d",
+					      self->fw_version & 0x00ff,
+					      (self->fw_version & 0xff00) >> 8); // TODO: Fix
+		break;
+	case ELAN_VENDOR_ID:
+		base_fw_ver = g_strdup_printf("%d.0", self->fw_version);
+		break;
+	default:
+		return FALSE;
+	}
+	fu_device_set_version(FU_DEVICE(self), base_fw_ver);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_hammer_touchpad_get_info(FuCrosEcHammerTouchpad *self, GError **error)
+{
+	FuDevice *parent = fu_device_get_parent(FU_DEVICE(self));
+	guint32 error_code;
+	guint16 subcommand = FU_CROS_EC_UPDATE_EXTRA_CMD_TOUCHPAD_INFO;
+	guint8 command_body[2] = {0x0}; /* max command body size */
+	gsize command_body_size = 0;
+	g_autoptr(FuStructCrosEcTouchpadGetInfoResponsePdu) tpi_rpdu =
+	    fu_struct_cros_ec_touchpad_get_info_response_pdu_new();
+	guint8 *response = tpi_rpdu->data;
+	gsize response_size = tpi_rpdu->len;
+	g_autoptr(GError) error_local = NULL;
+
+	g_return_val_if_fail(FU_IS_CROS_EC_USB_DEVICE(parent), FALSE);
+
+	if (!fu_cros_ec_usb_device_send_subcommand(FU_CROS_EC_USB_DEVICE(parent),
+						   subcommand,
+						   command_body,
+						   command_body_size,
+						   response,
+						   &response_size,
+						   FALSE,
+						   &error_local))
+		return FALSE;
+
+	error_code = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_status(tpi_rpdu);
+	if (error_code != 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "target touchpad reporting error %u",
+			    error_code);
+		return FALSE;
+	}
+
+	self->vendor = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_vendor(tpi_rpdu);
+	self->fw_address =
+	    fu_struct_cros_ec_touchpad_get_info_response_pdu_get_fw_address(tpi_rpdu);
+	self->fw_size = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_fw_size(tpi_rpdu);
+	self->allowed_fw_hash =
+	    fu_struct_cros_ec_touchpad_get_info_response_pdu_get_allowed_fw_hash(tpi_rpdu);
+	self->id = fu_struct_cros_ec_touchpad_get_info_response_pdu_get_id(tpi_rpdu);
+	self->fw_version =
+	    fu_struct_cros_ec_touchpad_get_info_response_pdu_get_fw_version(tpi_rpdu);
+	self->fw_checksum =
+	    fu_struct_cros_ec_touchpad_get_info_response_pdu_get_fw_checksum(tpi_rpdu);
+	fu_cros_ec_hammer_touchpad_set_version(self, error);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
 fu_cros_ec_hammer_touchpad_setup(FuDevice *device, GError **error)
 {
 	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(device);
-	guint32 error_code;
-	fu_device_set_version(FU_DEVICE(device), "1.1.1");
+
+	if (!fu_cros_ec_hammer_touchpad_get_info(self, error))
+		return FALSE;
+
+	/* success */
 	return TRUE;
 }
 
@@ -26,7 +120,7 @@ static void
 fu_cros_ec_hammer_touchpad_finalize(GObject *object)
 {
 	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(object);
-	g_free(self->raw_version);
+	g_free(self->allowed_fw_hash);
 	G_OBJECT_CLASS(fu_cros_ec_hammer_touchpad_parent_class)->finalize(object);
 }
 
@@ -37,9 +131,8 @@ fu_cros_ec_hammer_touchpad_init(FuCrosEcHammerTouchpad *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_DETACH_PREPARE_FIRMWARE);
-	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
-	// fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_CROS_EC_FIRMWARE);
 }
 
 static void
@@ -48,15 +141,7 @@ fu_cros_ec_hammer_touchpad_class_init(FuCrosEcHammerTouchpadClass *klass)
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_cros_ec_hammer_touchpad_finalize;
-	// device_class->prepare_firmware = fu_cros_ec_usb_device_prepare_firmware;
 	device_class->setup = fu_cros_ec_hammer_touchpad_setup;
-	// device_class->to_string = fu_cros_ec_usb_device_to_string;
-	// device_class->write_firmware = fu_cros_ec_usb_device_write_firmware;
-	// device_class->probe = fu_cros_ec_usb_device_probe;
-	// device_class->set_progress = fu_cros_ec_usb_device_set_progress;
-	// device_class->reload = fu_cros_ec_usb_device_reload;
-	// device_class->replace = fu_cros_ec_usb_device_replace;
-	// device_class->cleanup = fu_cros_ec_usb_device_cleanup;
 }
 
 FuCrosEcHammerTouchpad *

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.c
@@ -14,6 +14,8 @@
 #include "fu-cros-ec-struct.h"
 #include "fu-cros-ec-usb-device.h"
 
+#define SHA256_DIGEST_LENGTH 32
+
 #define ST_VENDOR_ID   0x0483
 #define ELAN_VENDOR_ID 0x04f3
 
@@ -140,6 +142,31 @@ fu_cros_ec_hammer_touchpad_setup(FuDevice *device, GError **error)
 	return TRUE;
 }
 
+gboolean
+fu_cros_ec_hammer_touchpad_firmware_validate(FuDevice *device, FuFirmware *firmware, GError **error)
+{
+	FuCrosEcHammerTouchpad *self = FU_CROS_EC_HAMMER_TOUCHPAD(device);
+	g_autoptr(GError) error_local = NULL;
+	GBytes *payload = NULL;
+	gsize fwsize;
+	gchar *fw = NULL;
+	;
+
+	payload = fu_firmware_get_bytes(firmware, error);
+	fw = g_bytes_get_data(payload, &fwsize);
+
+	if (self->fw_size != fwsize)
+		return FALSE;
+	g_info("Sizes Matches!");
+
+	gchar *digest = g_compute_checksum_for_data(G_CHECKSUM_SHA256, fw, fwsize);
+	if (g_strcmp0(digest, self->allowed_fw_hash) != 0)
+		return FALSE;
+	g_info("Checksum Matches!");
+
+	return FALSE; // Set to false to prevent updating
+}
+
 static FuFirmware *
 fu_cros_ec_hammer_touchpad_prepare_firmware(FuDevice *device,
 					    GInputStream *stream,
@@ -152,9 +179,7 @@ fu_cros_ec_hammer_touchpad_prepare_firmware(FuDevice *device,
 
 	if (!fu_firmware_parse_stream(firmware, stream, 0x0, flags, error))
 		return NULL;
-	if (!fu_cros_ec_hammer_touchpad_firmware_validate_checksum(
-		FU_CROS_EC_HAMMER_TOUCHPAD_FIRMWARE(firmware),
-		error))
+	if (!fu_cros_ec_hammer_touchpad_firmware_validate(device, firmware, error))
 		return NULL;
 
 	return g_steal_pointer(&firmware);

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.h
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.h
@@ -1,6 +1,14 @@
+/*
+ * Copyright 2025 Hamed Elgizery
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
 #pragma once
 
 #include <fwupdplugin.h>
+
+#include "fu-cros-ec-usb-device.h"
 
 #define FU_TYPE_CROS_EC_HAMMER_TOUCHPAD (fu_cros_ec_hammer_touchpad_get_type())
 G_DECLARE_FINAL_TYPE(FuCrosEcHammerTouchpad,

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.h
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_CROS_EC_HAMMER_TOUCHPAD (fu_cros_ec_hammer_touchpad_get_type())
+G_DECLARE_FINAL_TYPE(FuCrosEcHammerTouchpad,
+		     fu_cros_ec_hammer_touchpad,
+		     FU,
+		     CROS_EC_HAMMER_TOUCHPAD,
+		     FuDevice)
+
+FuCrosEcHammerTouchpad *
+fu_cros_ec_hammer_touchpad_new(FuDevice *proxy);

--- a/plugins/cros-ec/fu-cros-ec-hammer-touchpad.h
+++ b/plugins/cros-ec/fu-cros-ec-hammer-touchpad.h
@@ -17,5 +17,15 @@ G_DECLARE_FINAL_TYPE(FuCrosEcHammerTouchpad,
 		     CROS_EC_HAMMER_TOUCHPAD,
 		     FuDevice)
 
+struct _FuCrosEcHammerTouchpad {
+	FuDevice parent_instance;
+};
+
 FuCrosEcHammerTouchpad *
 fu_cros_ec_hammer_touchpad_new(FuDevice *proxy);
+
+guint32
+fu_cros_ec_hammer_touchpad_get_fw_address(FuCrosEcHammerTouchpad *self);
+
+guint32
+fu_cros_ec_hammer_touchpad_get_fw_size(FuCrosEcHammerTouchpad *self);

--- a/plugins/cros-ec/fu-cros-ec-plugin.c
+++ b/plugins/cros-ec/fu-cros-ec-plugin.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include "fu-cros-ec-firmware.h"
+#include "fu-cros-ec-hammer-touchpad-firmware.h"
 #include "fu-cros-ec-hammer-touchpad.h"
 #include "fu-cros-ec-plugin.h"
 #include "fu-cros-ec-usb-device.h"
@@ -28,6 +29,7 @@ fu_cros_ec_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CROS_EC_USB_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CROS_EC_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CROS_EC_HAMMER_TOUCHPAD_FIRMWARE);
 }
 
 static void

--- a/plugins/cros-ec/fu-cros-ec-plugin.c
+++ b/plugins/cros-ec/fu-cros-ec-plugin.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include "fu-cros-ec-firmware.h"
+#include "fu-cros-ec-hammer-touchpad.h"
 #include "fu-cros-ec-plugin.h"
 #include "fu-cros-ec-usb-device.h"
 

--- a/plugins/cros-ec/fu-cros-ec-plugin.c
+++ b/plugins/cros-ec/fu-cros-ec-plugin.c
@@ -11,6 +11,7 @@
 #include "fu-cros-ec-hammer-touchpad.h"
 #include "fu-cros-ec-plugin.h"
 #include "fu-cros-ec-usb-device.h"
+#include "fu-cros-ec-usb-hammer.h"
 
 struct _FuCrosEcPlugin {
 	FuPlugin parent_instance;
@@ -28,6 +29,7 @@ fu_cros_ec_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CROS_EC_USB_DEVICE);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_CROS_EC_USB_HAMMER);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CROS_EC_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CROS_EC_HAMMER_TOUCHPAD_FIRMWARE);
 }

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -924,7 +924,7 @@ fu_cros_ec_usb_device_write_touchpad_firmware(FuDevice *device,
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, blocks->len);
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	g_warning("(DEBUG) TO WRITE %d blocks to touchpad", blocks->len);
+	g_warning("(DEBUG) TO WRITE %u blocks to touchpad", blocks->len);
 	for (guint i = 0; i < blocks->len; i++) {
 		FuCrosEcUsbBlockHelper helper = {
 		    .block = g_ptr_array_index(blocks, i),

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -498,8 +498,10 @@ fu_cros_ec_usb_device_transfer_block_cb(FuDevice *device, gpointer user_data, GE
 	    fu_chunk_get_address(helper->block));
 
 	if (fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP)) {
-		/* Sets the cmd_block_digest with the first 32 bits of the SHA256 digest
-		 * as done in hammerd.*/
+		/* 
+                 * Sets the cmd_block_digest with the first 32 bits of the SHA256 digest
+		 * as done in hammerd.
+                 * */
 		gchar *digest = g_compute_checksum_for_data(G_CHECKSUM_SHA256,
 							    fu_chunk_get_data(helper->block),
 							    fu_chunk_get_data_sz(helper->block));
@@ -819,8 +821,10 @@ fu_cros_ec_usb_device_write_touchpad_firmware(FuDevice *device,
 
 	fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP);
 
-	// Probably, can be replaced with the CrosEcUsbDevice's maximum_pdu_size,
-	// but opting for independence here.
+	/*
+         * Probably, can be replaced with the CrosEcUsbDevice's maximum_pdu_size,
+	 * but opting for independence here.
+         */
 	maximum_pdu_size = fu_struct_cros_ec_first_response_pdu_get_maximum_pdu_size(st_rpdu);
 	img_bytes = fu_firmware_get_bytes(firmware, error);
 	data_ptr = (const guint8 *)g_bytes_get_data(img_bytes, &data_len);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -10,6 +10,7 @@
 
 #include "fu-cros-ec-common.h"
 #include "fu-cros-ec-firmware.h"
+#include "fu-cros-ec-hammer-touchpad.h"
 #include "fu-cros-ec-struct.h"
 #include "fu-cros-ec-usb-device.h"
 
@@ -25,6 +26,8 @@
 
 #define FU_CROS_EC_REQUEST_UPDATE_DONE	    0xB007AB1E
 #define FU_CROS_EC_REQUEST_UPDATE_EXTRA_CMD 0xB007AB1F
+
+#define FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD "has-touchpad"
 
 struct _FuCrosEcUsbDevice {
 	FuUsbDevice parent_instance;
@@ -340,6 +343,7 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 	g_autoptr(FuCrosEcVersion) active_version = NULL;
 	g_autoptr(FuCrosEcVersion) version = NULL;
 	g_autoptr(GError) error_local = NULL;
+	g_autoptr(FuCrosEcHammerTouchpad) touchpad = NULL;
 
 	/* FuUsbDevice->setup */
 	if (!FU_DEVICE_CLASS(fu_cros_ec_usb_device_parent_class)->setup(device, error))
@@ -451,6 +455,13 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 					 "BOARDNAME",
 					 NULL))
 		return FALSE;
+
+	if (fu_device_has_private_flag(device, FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD)) {
+		touchpad = fu_cros_ec_hammer_touchpad_new(FU_DEVICE(device));
+		if (!fu_device_setup(FU_DEVICE(touchpad), &error_local))
+			return FALSE;
+		fu_device_add_child(FU_DEVICE(device), FU_DEVICE(touchpad));
+	}
 
 	/* success */
 	return TRUE;
@@ -1006,6 +1017,8 @@ fu_cros_ec_usb_device_init(FuCrosEcUsbDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
+	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
+	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD);
 }
 
 static void

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -97,6 +97,22 @@ fu_cros_ec_usb_device_find_interface(FuUsbDevice *device, GError **error)
 	intfs = fu_usb_device_get_interfaces(device, error);
 	if (intfs == NULL)
 		return FALSE;
+	/*
+	 * NOTE, this might need fixing or might be okay...
+	 *
+	 * When working with hammer the interface that is targeted is the interface having
+	 * CLASS:FF, SUBCLASS:53, and PROTOCOL:FF (typically interface #1).
+	 *
+	 * Sometimes, while fwupd is parsing the USB descriptor it reads that interface 0 also has
+	 * this mentioned values, so it adds it to the device's interfaces.
+	 *
+	 * A guess here of what is happening; it could be that while the device is in bootloader
+	 * mode, the usb describtor might be intentionally altered for a while, and that could be
+	 * why it matches interface 0 as well. However, this doesn't cause a problem because when
+	 * fwupd tries to claim that interface, it fails either way and uses interface 1 instead.
+	 *
+	 * Might be worth having a look at to make sure whether this is a hammer
+	 * specific behavior, or a fwupd bug. */
 	for (guint i = 0; i < intfs->len; i++) {
 		FuUsbInterface *intf = g_ptr_array_index(intfs, i);
 		if (fu_usb_interface_get_class(intf) == 255 &&
@@ -498,10 +514,10 @@ fu_cros_ec_usb_device_transfer_block_cb(FuDevice *device, gpointer user_data, GE
 	    fu_chunk_get_address(helper->block));
 
 	if (fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP)) {
-		/* 
-                 * Sets the cmd_block_digest with the first 32 bits of the SHA256 digest
+		/*
+		 * Sets the cmd_block_digest with the first 32 bits of the SHA256 digest
 		 * as done in hammerd.
-                 * */
+		 * */
 		gchar *digest = g_compute_checksum_for_data(G_CHECKSUM_SHA256,
 							    fu_chunk_get_data(helper->block),
 							    fu_chunk_get_data_sz(helper->block));
@@ -710,6 +726,29 @@ fu_cros_ec_usb_device_send_subcommand(FuCrosEcUsbDevice *self,
 
 	/* success */
 	return TRUE;
+}
+
+static void
+fu_cros_ec_usb_device_unlock_rw(FuCrosEcUsbDevice *self)
+{
+	guint8 response = 0x0;
+	guint16 subcommand = FU_CROS_EC_UPDATE_EXTRA_CMD_UNLOCK_RW;
+	guint8 command_body[2] = {0x0}; /* max command body size */
+	gsize command_body_size = 0;
+	gsize response_size = 1;
+	g_autoptr(GError) error_local = NULL;
+
+	if (!fu_cros_ec_usb_device_send_subcommand(self,
+						   subcommand,
+						   command_body,
+						   command_body_size,
+						   &response,
+						   &response_size,
+						   FALSE,
+						   &error_local)) {
+		/* failure here is ok */
+		g_warning("unlock rw failed: reset: %s", error_local->message);
+	}
 }
 
 static void
@@ -930,6 +969,20 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 		return TRUE;
 	}
 
+	if (!fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) &&
+	    !self->in_bootloader) {
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
+		fu_cros_ec_usb_device_unlock_rw(self);
+		return TRUE;
+	}
+
+	if (!fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) &&
+	    self->in_bootloader && ((1 << 8) & self->flash_protection) != 0) {
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
+		fu_cros_ec_usb_device_unlock_rw(self);
+		return TRUE;
+	}
+
 	sections = fu_cros_ec_firmware_get_needed_sections(cros_ec_firmware, error);
 	if (sections == NULL)
 		return FALSE;
@@ -960,6 +1013,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 			return FALSE;
 		}
 
+		// TODO: Fix me, section->version.triplet has no data...
 		if (self->in_bootloader) {
 			fu_device_set_version(device, section->version.triplet);
 		} else {
@@ -1009,7 +1063,6 @@ fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
 		return NULL;
 	}
 
-	return NULL; // Stop the update
 	return g_steal_pointer(&firmware);
 }
 
@@ -1111,6 +1164,7 @@ fu_cros_ec_usb_device_init(FuCrosEcUsbDevice *self)
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_DETACH_PREPARE_FIRMWARE);
 	fu_device_set_acquiesce_delay(FU_DEVICE(self), 7500); /* ms */
+	fu_usb_device_set_claim_retry_count(FU_USB_DEVICE(self), FU_CROS_EC_SETUP_RETRY_CNT);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_CROS_EC_USB_DEVICE_REMOVE_DELAY);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_CROS_EC_FIRMWARE);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -434,7 +434,6 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 					  FU_STRUCT_CROS_EC_FIRST_RESPONSE_PDU_SIZE_VERSION);
 		version->dirty = active_version->dirty;
 	}
-
 	if (self->in_bootloader) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		fu_device_set_version(FU_DEVICE(device), version->triplet);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -1017,7 +1017,6 @@ fu_cros_ec_usb_device_init(FuCrosEcUsbDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
-	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD);
 }
 

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -1199,7 +1199,6 @@ fu_cros_ec_usb_device_init(FuCrosEcUsbDevice *self)
 					FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
-	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_DEVICE_FLAG_CHILDREN_SET);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD);
 }
 

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -733,14 +733,13 @@ fu_cros_ec_usb_device_send_subcommand(FuCrosEcUsbDevice *self,
 }
 
 static gboolean
-fu_cros_ec_usb_device_unlock_rw(FuCrosEcUsbDevice *self)
+fu_cros_ec_usb_device_unlock_rw(FuCrosEcUsbDevice *self, GError **error)
 {
 	guint8 response = 0x0;
 	guint16 subcommand = FU_CROS_EC_UPDATE_EXTRA_CMD_UNLOCK_RW;
 	guint8 command_body[2] = {0x0}; /* max command body size */
 	gsize command_body_size = 0;
 	gsize response_size = 1;
-	g_autoptr(GError) error_local = NULL;
 
 	if (!fu_cros_ec_usb_device_send_subcommand(self,
 						   subcommand,
@@ -749,8 +748,8 @@ fu_cros_ec_usb_device_unlock_rw(FuCrosEcUsbDevice *self)
 						   &response,
 						   &response_size,
 						   FALSE,
-						   &error_local)) {
-		g_prefix_error("unlock rw failed: %s", error_local->message);
+						   error)) {
+		g_prefix_error(error, "unlock rw failed:");
 		return FALSE;
 	}
 
@@ -1001,7 +1000,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 	if (!fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) &&
 	    (!self->in_bootloader || (self->flash_protection & (1 << 8)) != 0)) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
-		if (!fu_cros_ec_usb_device_unlock_rw(self))
+		if (!fu_cros_ec_usb_device_unlock_rw(self, error))
 			return FALSE;
 		return TRUE;
 	}

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -458,9 +458,9 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 
 	if (fu_device_has_private_flag(device, FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD)) {
 		touchpad = fu_cros_ec_hammer_touchpad_new(FU_DEVICE(device));
+		fu_device_add_child(FU_DEVICE(device), FU_DEVICE(touchpad));
 		if (!fu_device_setup(FU_DEVICE(touchpad), &error_local))
 			return FALSE;
-		fu_device_add_child(FU_DEVICE(device), FU_DEVICE(touchpad));
 	}
 
 	/* success */
@@ -660,7 +660,7 @@ fu_cros_ec_usb_device_send_done(FuCrosEcUsbDevice *self)
 	}
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_send_subcommand(FuCrosEcUsbDevice *self,
 				      guint16 subcommand,
 				      guint8 *cmd_body,

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -996,6 +996,8 @@ fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
 		g_prefix_error(error, "failed to pick sections: ");
 		return NULL;
 	}
+
+	return NULL; // Stop the update
 	return g_steal_pointer(&firmware);
 }
 

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -10,25 +10,10 @@
 
 #include "fu-cros-ec-common.h"
 #include "fu-cros-ec-firmware.h"
-#include "fu-cros-ec-hammer-touchpad-firmware.h"
-#include "fu-cros-ec-hammer-touchpad.h"
 #include "fu-cros-ec-struct.h"
 #include "fu-cros-ec-usb-device.h"
 
-#define FU_CROS_EC_USB_SUBCLASS_GOOGLE_UPDATE 0x53
-#define FU_CROS_EC_USB_PROTOCOL_GOOGLE_UPDATE 0xff
-
-#define FU_CROS_EC_MAX_BLOCK_XFER_RETRIES  10
-#define FU_CROS_EC_FLUSH_TIMEOUT_MS	   10
-#define FU_CROS_EC_BULK_SEND_TIMEOUT	   2000 /* ms */
-#define FU_CROS_EC_BULK_RECV_TIMEOUT	   5000 /* ms */
-#define FU_CROS_EC_USB_DEVICE_REMOVE_DELAY 20000
-
-#define FU_CROS_EC_REQUEST_UPDATE_DONE	    0xB007AB1E
-#define FU_CROS_EC_REQUEST_UPDATE_EXTRA_CMD 0xB007AB1F
-
-struct _FuCrosEcUsbDevice {
-	FuUsbDevice parent_instance;
+typedef struct {
 	guint8 iface_idx;  /* bInterfaceNumber */
 	guint8 ep_num;	   /* bEndpointAddress */
 	guint16 chunk_len; /* wMaxPacketSize */
@@ -39,32 +24,162 @@ struct _FuCrosEcUsbDevice {
 	guint16 protocol_version;
 	gchar configuration[FU_STRUCT_CROS_EC_FIRST_RESPONSE_PDU_SIZE_VERSION];
 	gboolean in_bootloader;
-};
+} FuCrosEcUsbDevicePrivate;
 
-G_DEFINE_TYPE(FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU_TYPE_USB_DEVICE)
+G_DEFINE_TYPE_WITH_PRIVATE(FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU_TYPE_USB_DEVICE)
+#define GET_PRIVATE(o) (fu_cros_ec_usb_device_get_instance_private(o))
 
 typedef struct {
 	FuChunk *block;
 	FuProgress *progress;
 } FuCrosEcUsbBlockHelper;
 
-#define FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN	   "ro-written"
-#define FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN	   "rw-written"
-#define FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO "rebooting-to-ro"
-#define FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP	   "updating-touchpad"
-#define FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL	   "special"
-#define FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD	   "has-touchpad"
+guint8
+fu_cros_ec_usb_device_get_iface_idx(FuCrosEcUsbDevice *self)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->iface_idx;
+}
+
+guint8
+fu_cros_ec_usb_device_get_ep_num(FuCrosEcUsbDevice *self)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->ep_num;
+}
+
+guint16
+fu_cros_ec_usb_device_get_chunk_len(FuCrosEcUsbDevice *self)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->chunk_len;
+}
+
+gchar *
+fu_cros_ec_usb_device_get_raw_version(FuCrosEcUsbDevice *self)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->raw_version;
+}
+
+guint32
+fu_cros_ec_usb_device_get_maximum_pdu_size(FuCrosEcUsbDevice *self)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->maximum_pdu_size;
+}
+
+guint32
+fu_cros_ec_usb_device_get_flash_protection(FuCrosEcUsbDevice *self)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->flash_protection;
+}
+
+guint32
+fu_cros_ec_usb_device_get_writeable_offset(FuCrosEcUsbDevice *self)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->writeable_offset;
+}
+
+guint16
+fu_cros_ec_usb_device_get_protocol_version(FuCrosEcUsbDevice *self)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->protocol_version;
+}
+
+gchar *
+fu_cros_ec_usb_device_get_configuration(FuCrosEcUsbDevice *self)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->configuration;
+}
 
 gboolean
-fu_cros_ec_usb_device_get_in_bootloader(FuDevice *device)
+fu_cros_ec_usb_device_get_in_bootloader(FuCrosEcUsbDevice *self)
 {
-	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
-	return self->in_bootloader;
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->in_bootloader;
+}
+
+void
+fu_cros_ec_usb_device_set_iface_idx(FuCrosEcUsbDevice *self, guint8 iface_idx)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	priv->iface_idx = iface_idx;
+}
+
+void
+fu_cros_ec_usb_device_set_ep_num(FuCrosEcUsbDevice *self, guint8 ep_num)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	priv->ep_num = ep_num;
+}
+
+void
+fu_cros_ec_usb_device_set_chunk_len(FuCrosEcUsbDevice *self, guint16 chunk_len)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	priv->chunk_len = chunk_len;
+}
+
+void
+fu_cros_ec_usb_device_set_raw_version(FuCrosEcUsbDevice *self, const gchar *raw_version)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	priv->raw_version = g_strdup(raw_version);
+}
+
+void
+fu_cros_ec_usb_device_set_maximum_pdu_size(FuCrosEcUsbDevice *self, guint32 maximum_pdu_size)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	priv->maximum_pdu_size = maximum_pdu_size;
+}
+
+void
+fu_cros_ec_usb_device_set_flash_protection(FuCrosEcUsbDevice *self, guint32 flash_protection)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	priv->flash_protection = flash_protection;
+}
+
+void
+fu_cros_ec_usb_device_set_writeable_offset(FuCrosEcUsbDevice *self, guint32 writeable_offset)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	priv->writeable_offset = writeable_offset;
+}
+
+void
+fu_cros_ec_usb_device_set_protocol_version(FuCrosEcUsbDevice *self, guint16 protocol_version)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	priv->protocol_version = protocol_version;
+}
+
+void
+fu_cros_ec_usb_device_set_configuration(FuCrosEcUsbDevice *self, const gchar *configuration)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	g_strlcpy(priv->configuration,
+		  configuration,
+		  FU_STRUCT_CROS_EC_FIRST_RESPONSE_PDU_SIZE_VERSION);
+}
+
+void
+fu_cros_ec_usb_device_set_in_bootloader(FuCrosEcUsbDevice *self, gboolean in_bootloader)
+{
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	priv->in_bootloader = in_bootloader;
 }
 
 static gboolean
-fu_cros_ec_usb_device_get_configuration(FuCrosEcUsbDevice *self, GError **error)
+fu_cros_ec_usb_device_read_configuration(FuCrosEcUsbDevice *self, GError **error)
 {
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 index;
 	g_autofree gchar *configuration = NULL;
 
@@ -79,7 +194,7 @@ fu_cros_ec_usb_device_get_configuration(FuCrosEcUsbDevice *self, GError **error)
 		fu_device_get_name(FU_DEVICE(self)),
 		configuration);
 
-	if (g_strlcpy(self->configuration,
+	if (g_strlcpy(priv->configuration,
 		      configuration,
 		      FU_STRUCT_CROS_EC_FIRST_RESPONSE_PDU_SIZE_VERSION) == 0) {
 		g_set_error_literal(error,
@@ -97,6 +212,7 @@ static gboolean
 fu_cros_ec_usb_device_find_interface(FuUsbDevice *device, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GPtrArray) intfs = NULL;
 
 	/* based on usb_updater2's find_interfacei() and find_endpoint() */
@@ -113,9 +229,9 @@ fu_cros_ec_usb_device_find_interface(FuUsbDevice *device, GError **error)
 			if (NULL == endpoints || endpoints->len == 0)
 				continue;
 			ep = g_ptr_array_index(endpoints, 0);
-			self->iface_idx = fu_usb_interface_get_number(intf);
-			self->ep_num = fu_usb_endpoint_get_address(ep) & 0x7f;
-			self->chunk_len = fu_usb_endpoint_get_maximum_packet_size(ep);
+			priv->iface_idx = fu_usb_interface_get_number(intf);
+			priv->ep_num = fu_usb_endpoint_get_address(ep) & 0x7f;
+			priv->chunk_len = fu_usb_endpoint_get_maximum_packet_size(ep);
 			return TRUE;
 		}
 	}
@@ -123,27 +239,11 @@ fu_cros_ec_usb_device_find_interface(FuUsbDevice *device, GError **error)
 	return FALSE;
 }
 
-static gboolean
-fu_cros_ec_usb_device_ensure_children(FuCrosEcUsbDevice *self, GError **error)
-{
-	FuDevice *device = FU_DEVICE(self);
-	g_autoptr(FuCrosEcHammerTouchpad) touchpad = NULL;
-
-	if (!fu_device_has_private_flag(device, FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD))
-		return TRUE;
-
-	touchpad = fu_cros_ec_hammer_touchpad_new(FU_DEVICE(device));
-	fu_device_add_child(FU_DEVICE(device), FU_DEVICE(touchpad));
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
+gboolean
 fu_cros_ec_usb_device_probe(FuDevice *device, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
-	g_autoptr(FuCrosEcHammerTouchpad) touchpad = NULL;
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GError) error_local = NULL;
 
 	/* very much like usb_updater2's usb_findit() */
@@ -151,14 +251,14 @@ fu_cros_ec_usb_device_probe(FuDevice *device, GError **error)
 		g_prefix_error(error, "failed to find update interface: ");
 		return FALSE;
 	}
-	fu_usb_device_add_interface(FU_USB_DEVICE(self), self->iface_idx);
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), priv->iface_idx);
 
-	if (self->chunk_len == 0) {
+	if (priv->chunk_len == 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
 			    "wMaxPacketSize isn't valid: %" G_GUINT16_FORMAT,
-			    self->chunk_len);
+			    priv->chunk_len);
 		return FALSE;
 	}
 
@@ -176,6 +276,7 @@ fu_cros_ec_usb_device_do_xfer(FuCrosEcUsbDevice *self,
 			      gsize *rxed_count,
 			      GError **error)
 {
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	gsize actual = 0;
 
 	/* send data out */
@@ -188,7 +289,7 @@ fu_cros_ec_usb_device_do_xfer(FuCrosEcUsbDevice *self,
 			return FALSE;
 
 		if (!fu_usb_device_bulk_transfer(FU_USB_DEVICE(self),
-						 self->ep_num,
+						 priv->ep_num,
 						 outbuf_tmp,
 						 outlen,
 						 &actual,
@@ -211,7 +312,7 @@ fu_cros_ec_usb_device_do_xfer(FuCrosEcUsbDevice *self,
 	if (inbuf != NULL && inlen > 0) {
 		actual = 0;
 		if (!fu_usb_device_bulk_transfer(FU_USB_DEVICE(self),
-						 self->ep_num | 0x80,
+						 priv->ep_num | 0x80,
 						 inbuf,
 						 inlen,
 						 &actual,
@@ -238,20 +339,21 @@ fu_cros_ec_usb_device_do_xfer(FuCrosEcUsbDevice *self,
 	return TRUE;
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_flush(FuDevice *device, gpointer user_data, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	gsize actual = 0;
-	g_autofree guint8 *inbuf = g_malloc0(self->chunk_len);
+	g_autofree guint8 *inbuf = g_malloc0(priv->chunk_len);
 
 	/* bulk transfer expected to fail normally (ie, no stale data)
 	 * but if bulk transfer succeeds, indicates stale bytes on the device
 	 * so this will retry until they're emptied */
 	if (fu_usb_device_bulk_transfer(FU_USB_DEVICE(self),
-					self->ep_num | 0x80,
+					priv->ep_num | 0x80,
 					inbuf,
-					self->chunk_len,
+					priv->chunk_len,
 					&actual,
 					FU_CROS_EC_FLUSH_TIMEOUT_MS,
 					NULL,
@@ -269,7 +371,7 @@ fu_cros_ec_usb_device_flush(FuDevice *device, gpointer user_data, GError **error
 	return TRUE;
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_recovery(FuCrosEcUsbDevice *self, GError **error)
 {
 	/* flush all data from endpoint to recover in case of error */
@@ -357,12 +459,12 @@ fu_cros_ec_usb_device_start_request_cb(FuDevice *device, gpointer user_data, GEr
 	return TRUE;
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	guint32 error_code;
-	g_autoptr(FuCrosEcHammerTouchpad) touchpad = NULL;
 	g_auto(GStrv) config_split = NULL;
 	g_autoptr(FuStructCrosEcFirstResponsePdu) st_rpdu =
 	    fu_struct_cros_ec_first_response_pdu_new();
@@ -387,13 +489,13 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 		return FALSE;
 	}
 
-	self->protocol_version = fu_struct_cros_ec_first_response_pdu_get_protocol_version(st_rpdu);
-	if (self->protocol_version < 5 || self->protocol_version > 6) {
+	priv->protocol_version = fu_struct_cros_ec_first_response_pdu_get_protocol_version(st_rpdu);
+	if (priv->protocol_version < 5 || priv->protocol_version > 6) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "unsupported protocol version %d",
-			    self->protocol_version);
+			    priv->protocol_version);
 		return FALSE;
 	}
 
@@ -407,28 +509,28 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 		return FALSE;
 	}
 
-	self->writeable_offset = fu_struct_cros_ec_first_response_pdu_get_offset(st_rpdu);
-	g_free(self->raw_version);
-	self->raw_version = fu_struct_cros_ec_first_response_pdu_get_version(st_rpdu);
-	self->maximum_pdu_size = fu_struct_cros_ec_first_response_pdu_get_maximum_pdu_size(st_rpdu);
-	self->flash_protection = fu_struct_cros_ec_first_response_pdu_get_flash_protection(st_rpdu);
+	priv->writeable_offset = fu_struct_cros_ec_first_response_pdu_get_offset(st_rpdu);
+	g_free(priv->raw_version);
+	priv->raw_version = fu_struct_cros_ec_first_response_pdu_get_version(st_rpdu);
+	priv->maximum_pdu_size = fu_struct_cros_ec_first_response_pdu_get_maximum_pdu_size(st_rpdu);
+	priv->flash_protection = fu_struct_cros_ec_first_response_pdu_get_flash_protection(st_rpdu);
 
 	/* get active version string and running region from iConfiguration */
-	if (!fu_cros_ec_usb_device_get_configuration(self, error))
+	if (!fu_cros_ec_usb_device_read_configuration(self, error))
 		return FALSE;
-	config_split = g_strsplit(self->configuration, ":", 2);
+	config_split = g_strsplit(priv->configuration, ":", 2);
 	if (g_strv_length(config_split) < 2) {
 		/* no prefix found so fall back to offset */
-		self->in_bootloader = self->writeable_offset != 0x0;
-		active_version = fu_cros_ec_version_parse(self->configuration, error);
+		priv->in_bootloader = priv->writeable_offset != 0x0;
+		active_version = fu_cros_ec_version_parse(priv->configuration, error);
 		if (active_version == NULL) {
 			g_prefix_error(error,
 				       "failed parsing device's version: %32s: ",
-				       self->configuration);
+				       priv->configuration);
 			return FALSE;
 		}
 	} else {
-		self->in_bootloader = g_strcmp0("RO", config_split[0]) == 0;
+		priv->in_bootloader = g_strcmp0("RO", config_split[0]) == 0;
 		active_version = fu_cros_ec_version_parse(config_split[1], error);
 		if (active_version == NULL) {
 			g_prefix_error(error,
@@ -439,13 +541,13 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 	}
 
 	/* get the other region's version string from targ */
-	version = fu_cros_ec_version_parse(self->raw_version, &error_local);
+	version = fu_cros_ec_version_parse(priv->raw_version, &error_local);
 	if (version == NULL) {
-		if (!self->in_bootloader) {
+		if (!priv->in_bootloader) {
 			g_propagate_prefixed_error(error,
 						   g_steal_pointer(&error_local),
 						   "failed parsing device's version: %32s: ",
-						   self->raw_version);
+						   priv->raw_version);
 			return FALSE;
 		}
 		/* if unable to parse version, copy from the active_version.
@@ -459,7 +561,7 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 					  FU_STRUCT_CROS_EC_FIRST_RESPONSE_PDU_SIZE_VERSION);
 		version->dirty = active_version->dirty;
 	}
-	if (self->in_bootloader) {
+	if (priv->in_bootloader) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		fu_device_set_version(FU_DEVICE(device), version->triplet);
 		fu_device_set_version_bootloader(FU_DEVICE(device), active_version->triplet);
@@ -480,14 +582,11 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 					 NULL))
 		return FALSE;
 
-	if (!fu_cros_ec_usb_device_ensure_children(self, error))
-		return FALSE;
-
 	/* success */
 	return TRUE;
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_reload(FuDevice *device, GError **error)
 {
 	if (fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN) &&
@@ -498,10 +597,11 @@ fu_cros_ec_usb_device_reload(FuDevice *device, GError **error)
 	return TRUE;
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_transfer_block_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	FuCrosEcUsbBlockHelper *helper = (FuCrosEcUsbBlockHelper *)user_data;
 	gsize transfer_size = 0;
 	guint32 reply = 0;
@@ -562,7 +662,7 @@ fu_cros_ec_usb_device_transfer_block_cb(FuDevice *device, gpointer user_data, GE
 				    fu_chunk_get_data_sz(helper->block),
 				    0x00,
 				    0x00,
-				    self->chunk_len);
+				    priv->chunk_len);
 	fu_progress_set_id(helper->progress, G_STRLOC);
 	fu_progress_set_steps(helper->progress, chunks->len);
 	for (guint i = 0; i < chunks->len; i++) {
@@ -619,13 +719,14 @@ fu_cros_ec_usb_device_transfer_block_cb(FuDevice *device, gpointer user_data, GE
 	return TRUE;
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_transfer_section(FuCrosEcUsbDevice *self,
 				       FuFirmware *firmware,
 				       FuCrosEcFirmwareSection *section,
 				       FuProgress *progress,
 				       GError **error)
 {
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	const guint8 *data_ptr = NULL;
 	gsize data_len = 0;
 	g_autoptr(GBytes) img_bytes = NULL;
@@ -659,7 +760,7 @@ fu_cros_ec_usb_device_transfer_section(FuCrosEcUsbDevice *self,
 
 	/* send in chunks of PDU size */
 	blocks =
-	    fu_chunk_array_new(data_ptr, data_len, section->offset, 0x0, self->maximum_pdu_size);
+	    fu_chunk_array_new(data_ptr, data_len, section->offset, 0x0, priv->maximum_pdu_size);
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, blocks->len);
 	for (guint i = 0; i < blocks->len; i++) {
@@ -682,7 +783,7 @@ fu_cros_ec_usb_device_transfer_section(FuCrosEcUsbDevice *self,
 	return TRUE;
 }
 
-static void
+void
 fu_cros_ec_usb_device_send_done(FuCrosEcUsbDevice *self)
 {
 	guint8 buf[1] = {0x0};
@@ -732,7 +833,7 @@ fu_cros_ec_usb_device_send_subcommand(FuCrosEcUsbDevice *self,
 	return TRUE;
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_unlock_rw(FuCrosEcUsbDevice *self, GError **error)
 {
 	guint8 response = 0x0;
@@ -757,7 +858,7 @@ fu_cros_ec_usb_device_unlock_rw(FuCrosEcUsbDevice *self, GError **error)
 	return TRUE;
 }
 
-static void
+void
 fu_cros_ec_usb_device_reset_to_ro(FuCrosEcUsbDevice *self)
 {
 	guint8 response = 0x0;
@@ -811,7 +912,7 @@ fu_cros_ec_usb_device_jump_to_rw(FuCrosEcUsbDevice *self)
 	return TRUE;
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_stay_in_ro(FuCrosEcUsbDevice *self, GError **error)
 {
 	gsize response_size = 1;
@@ -834,96 +935,6 @@ fu_cros_ec_usb_device_stay_in_ro(FuCrosEcUsbDevice *self, GError **error)
 	return TRUE;
 }
 
-gboolean
-fu_cros_ec_usb_device_write_touchpad_firmware(FuDevice *device,
-					      FuFirmware *firmware,
-					      FuProgress *progress,
-					      FwupdInstallFlags flags,
-					      FuDevice *tp_device,
-					      GError **error)
-{
-	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
-	FuCrosEcHammerTouchpad *touchpad = FU_CROS_EC_HAMMER_TOUCHPAD(tp_device);
-	gsize data_len = 0;
-	guint32 maximum_pdu_size = 0;
-	guint32 tp_fw_size = 0;
-	guint32 tp_fw_address = 0;
-	const guint8 *data_ptr = NULL;
-	g_autoptr(GBytes) img_bytes = NULL;
-	g_autoptr(GPtrArray) blocks = NULL;
-	g_autoptr(FuStructCrosEcFirstResponsePdu) st_rpdu =
-	    fu_struct_cros_ec_first_response_pdu_new();
-
-	/* send start request */
-	if (!fu_device_retry(device,
-			     fu_cros_ec_usb_device_start_request_cb,
-			     FU_CROS_EC_SETUP_RETRY_CNT,
-			     st_rpdu,
-			     error)) {
-		g_prefix_error(error, "touchpad: failed to send start request: ");
-		return FALSE;
-	}
-
-	fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP);
-
-	/*
-	 * Probably, can be replaced with the CrosEcUsbDevice's maximum_pdu_size,
-	 * but opting for independence here.
-	 */
-	maximum_pdu_size = fu_struct_cros_ec_first_response_pdu_get_maximum_pdu_size(st_rpdu);
-	img_bytes = fu_firmware_get_bytes(firmware, error);
-	data_ptr = (const guint8 *)g_bytes_get_data(img_bytes, &data_len);
-	tp_fw_address = fu_cros_ec_hammer_touchpad_get_fw_address(touchpad);
-	tp_fw_size = fu_cros_ec_hammer_touchpad_get_fw_size(touchpad);
-
-	if (tp_fw_address != (1u << 31)) { // This is for testing safety only, should be removed
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_DATA,
-				    "CRITICAL DEVICE ABOUT TO BE BRICKED HALTING");
-		return FALSE;
-	}
-
-	if (data_ptr == NULL || data_len != tp_fw_size) {
-		g_set_error(
-		    error,
-		    FWUPD_ERROR,
-		    FWUPD_ERROR_INVALID_DATA,
-		    "touchpad: image and section sizes do not match: image = %" G_GSIZE_FORMAT
-		    " bytes vs touchpad section size = %" G_GSIZE_FORMAT " bytes",
-		    data_len,
-		    (gsize)tp_fw_size);
-		return FALSE;
-	}
-
-	g_debug("touchpad: sending 0x%x bytes to 0x%x", (guint)data_len, tp_fw_address);
-
-	blocks =
-	    /* send in chunks of PDU size */
-	    fu_chunk_array_new(data_ptr, data_len, tp_fw_address, 0x0, maximum_pdu_size);
-	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, blocks->len);
-	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	for (guint i = 0; i < blocks->len; i++) {
-		FuCrosEcUsbBlockHelper helper = {
-		    .block = g_ptr_array_index(blocks, i),
-		    .progress = fu_progress_get_child(progress),
-		};
-		if (!fu_device_retry(FU_DEVICE(self),
-				     fu_cros_ec_usb_device_transfer_block_cb,
-				     FU_CROS_EC_MAX_BLOCK_XFER_RETRIES,
-				     &helper,
-				     error)) {
-			g_prefix_error(error, "touchpad: failed to transfer block 0x%x: ", i);
-			return FALSE;
-		}
-		fu_progress_step_done(progress);
-	}
-
-	fu_device_remove_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP);
-	return TRUE;
-}
-
 static gboolean
 fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 				     FuFirmware *firmware,
@@ -932,6 +943,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 				     GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GPtrArray) sections = NULL;
 	FuCrosEcFirmware *cros_ec_firmware = FU_CROS_EC_FIRMWARE(firmware);
 
@@ -965,7 +977,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 	}
 
 	if (fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) &&
-	    self->in_bootloader) {
+	    priv->in_bootloader) {
 		/*
 		 * We had previously written to the rw region (while we were
 		 * booted from ro region), but somehow landed in ro again after
@@ -998,7 +1010,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 	 * protection disabled with the next write attempt.
 	 */
 	if (!fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) &&
-	    (!self->in_bootloader || (self->flash_protection & (1 << 8)) != 0)) {
+	    (!priv->in_bootloader || (priv->flash_protection & (1 << 8)) != 0)) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
 		if (!fu_cros_ec_usb_device_unlock_rw(self, error))
 			return FALSE;
@@ -1036,7 +1048,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 		}
 
 		// TODO: Fix me, section->version.triplet has no data...
-		if (self->in_bootloader) {
+		if (priv->in_bootloader) {
 			fu_device_set_version(device, section->version.triplet);
 		} else {
 			fu_device_set_version_bootloader(device, section->version.triplet);
@@ -1048,7 +1060,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 	/* send done */
 	fu_cros_ec_usb_device_send_done(self);
 
-	if (self->in_bootloader)
+	if (priv->in_bootloader)
 		fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN);
 	else
 		fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN);
@@ -1062,7 +1074,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 	return TRUE;
 }
 
-static FuFirmware *
+FuFirmware *
 fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
 				       GInputStream *stream,
 				       FuProgress *progress,
@@ -1070,6 +1082,7 @@ fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
 				       GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(FuFirmware) firmware = fu_cros_ec_firmware_new();
 
 	if (!fu_firmware_parse_stream(firmware, stream, 0x0, flags, error))
@@ -1079,7 +1092,7 @@ fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
 
 	/* pick sections */
 	if (!fu_cros_ec_firmware_pick_sections(FU_CROS_EC_FIRMWARE(firmware),
-					       self->writeable_offset,
+					       priv->writeable_offset,
 					       error)) {
 		g_prefix_error(error, "failed to pick sections: ");
 		return NULL;
@@ -1088,12 +1101,13 @@ fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
 	return g_steal_pointer(&firmware);
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 
-	if (self->in_bootloader &&
+	if (priv->in_bootloader &&
 	    fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL)) {
 		/*
 		 * attach after the SPECIAL flag was set. The EC will auto-jump
@@ -1121,16 +1135,17 @@ fu_cros_ec_usb_device_attach(FuDevice *device, FuProgress *progress, GError **er
 	return TRUE;
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
 
 	if (fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) &&
 	    !fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN))
 		return TRUE;
 
-	if (self->in_bootloader) {
+	if (priv->in_bootloader) {
 		/* If EC just rebooted - prevent jumping to RW during the update */
 		fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO);
 		g_debug("skipping immediate reboot in case of already in bootloader");
@@ -1138,7 +1153,7 @@ fu_cros_ec_usb_device_detach(FuDevice *device, FuProgress *progress, GError **er
 		return TRUE;
 	}
 
-	if (self->flash_protection != 0x0) {
+	if (priv->flash_protection != 0x0) {
 		/* in RW, and RO region is write protected, so jump to RO */
 		fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN);
 		fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO);
@@ -1150,7 +1165,7 @@ fu_cros_ec_usb_device_detach(FuDevice *device, FuProgress *progress, GError **er
 	return TRUE;
 }
 
-static void
+void
 fu_cros_ec_usb_device_replace(FuDevice *device, FuDevice *donor)
 {
 	if (fu_device_has_private_flag(donor, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN))
@@ -1163,7 +1178,7 @@ fu_cros_ec_usb_device_replace(FuDevice *device, FuDevice *donor)
 		fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
 }
 
-static gboolean
+gboolean
 fu_cros_ec_usb_device_cleanup(FuDevice *device,
 			      FuProgress *progress,
 			      FwupdInstallFlags flags,
@@ -1201,18 +1216,19 @@ fu_cros_ec_usb_device_init(FuCrosEcUsbDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self), FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD);
 }
 
-static void
+void
 fu_cros_ec_usb_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
-	fwupd_codec_string_append_int(str, idt, "ProtocolVersion", self->protocol_version);
-	fwupd_codec_string_append_int(str, idt, "MaxPduSize", self->maximum_pdu_size);
-	fwupd_codec_string_append_hex(str, idt, "FlashProtection", self->flash_protection);
-	fwupd_codec_string_append(str, idt, "RawVersion", self->raw_version);
-	fwupd_codec_string_append_hex(str, idt, "WriteableOffset", self->writeable_offset);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	fwupd_codec_string_append_int(str, idt, "ProtocolVersion", priv->protocol_version);
+	fwupd_codec_string_append_int(str, idt, "MaxPduSize", priv->maximum_pdu_size);
+	fwupd_codec_string_append_hex(str, idt, "FlashProtection", priv->flash_protection);
+	fwupd_codec_string_append(str, idt, "RawVersion", priv->raw_version);
+	fwupd_codec_string_append_hex(str, idt, "WriteableOffset", priv->writeable_offset);
 }
 
-static void
+void
 fu_cros_ec_usb_device_set_progress(FuDevice *self, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
@@ -1223,11 +1239,12 @@ fu_cros_ec_usb_device_set_progress(FuDevice *self, FuProgress *progress)
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 22, "reload");
 }
 
-static void
+void
 fu_cros_ec_usb_device_finalize(GObject *object)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(object);
-	g_free(self->raw_version);
+	FuCrosEcUsbDevicePrivate *priv = GET_PRIVATE(self);
+	g_free(priv->raw_version);
 	G_OBJECT_CLASS(fu_cros_ec_usb_device_parent_class)->finalize(object);
 }
 

--- a/plugins/cros-ec/fu-cros-ec-usb-device.h
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.h
@@ -35,3 +35,5 @@ fu_cros_ec_usb_device_write_touchpad_firmware(FuDevice *device,
 					      FwupdInstallFlags flags,
 					      FuDevice *tp_device,
 					      GError **error);
+gboolean
+fu_cros_ec_usb_device_get_in_bootloader(FuDevice *device);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.h
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.h
@@ -8,6 +8,10 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-cros-ec-hammer-touchpad.h"
+
+#define FU_CROS_EC_SETUP_RETRY_CNT 5
+
 #define FU_TYPE_CROS_EC_USB_DEVICE (fu_cros_ec_usb_device_get_type())
 G_DECLARE_FINAL_TYPE(FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU, CROS_EC_USB_DEVICE, FuUsbDevice)
 
@@ -20,3 +24,14 @@ fu_cros_ec_usb_device_send_subcommand(FuCrosEcUsbDevice *self,
 				      gsize *resp_size,
 				      gboolean allow_less,
 				      GError **error);
+
+gboolean
+fu_cros_ec_usb_device_start_request_cb(FuDevice *device, gpointer user_data, GError **error);
+
+gboolean
+fu_cros_ec_usb_device_write_touchpad_firmware(FuDevice *device,
+					      FuFirmware *firmware,
+					      FuProgress *progress,
+					      FwupdInstallFlags flags,
+					      FuDevice *tp_device,
+					      GError **error);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.h
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.h
@@ -8,12 +8,90 @@
 
 #include <fwupdplugin.h>
 
-#include "fu-cros-ec-hammer-touchpad.h"
+#include "fu-cros-ec-firmware.h"
 
 #define FU_CROS_EC_SETUP_RETRY_CNT 5
 
 #define FU_TYPE_CROS_EC_USB_DEVICE (fu_cros_ec_usb_device_get_type())
-G_DECLARE_FINAL_TYPE(FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU, CROS_EC_USB_DEVICE, FuUsbDevice)
+G_DECLARE_DERIVABLE_TYPE(FuCrosEcUsbDevice,
+			 fu_cros_ec_usb_device,
+			 FU,
+			 CROS_EC_USB_DEVICE,
+			 FuUsbDevice)
+
+struct _FuCrosEcUsbDeviceClass {
+	FuUsbDeviceClass parent_class;
+};
+
+#define FU_CROS_EC_USB_SUBCLASS_GOOGLE_UPDATE 0x53
+#define FU_CROS_EC_USB_PROTOCOL_GOOGLE_UPDATE 0xff
+
+#define FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN	   "ro-written"
+#define FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN	   "rw-written"
+#define FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP	   "updating-touchpad"
+#define FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO "rebooting-to-ro"
+#define FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL	   "special"
+#define FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD	   "has-touchpad"
+
+guint8
+fu_cros_ec_usb_device_get_iface_idx(FuCrosEcUsbDevice *self);
+
+guint8
+fu_cros_ec_usb_device_get_ep_num(FuCrosEcUsbDevice *self);
+
+guint16
+fu_cros_ec_usb_device_get_chunk_len(FuCrosEcUsbDevice *self);
+
+gchar *
+fu_cros_ec_usb_device_get_raw_version(FuCrosEcUsbDevice *self);
+
+guint32
+fu_cros_ec_usb_device_get_maximum_pdu_size(FuCrosEcUsbDevice *self);
+
+guint32
+fu_cros_ec_usb_device_get_flash_protection(FuCrosEcUsbDevice *self);
+
+guint32
+fu_cros_ec_usb_device_get_writeable_offset(FuCrosEcUsbDevice *self);
+
+guint16
+fu_cros_ec_usb_device_get_protocol_version(FuCrosEcUsbDevice *self);
+
+gchar *
+fu_cros_ec_usb_device_get_configuration(FuCrosEcUsbDevice *self);
+
+gboolean
+fu_cros_ec_usb_device_get_in_bootloader(FuCrosEcUsbDevice *self);
+
+void
+fu_cros_ec_usb_device_set_iface_idx(FuCrosEcUsbDevice *self, guint8 iface_idx);
+
+void
+fu_cros_ec_usb_device_set_ep_num(FuCrosEcUsbDevice *self, guint8 ep_num);
+
+void
+fu_cros_ec_usb_device_set_chunk_len(FuCrosEcUsbDevice *self, guint16 chunk_len);
+
+void
+fu_cros_ec_usb_device_set_raw_version(FuCrosEcUsbDevice *self, const gchar *raw_version);
+
+void
+fu_cros_ec_usb_device_set_maximum_pdu_size(FuCrosEcUsbDevice *self, guint32 maximum_pdu_size);
+
+void
+fu_cros_ec_usb_device_set_flash_protection(FuCrosEcUsbDevice *self, guint32 flash_protection);
+
+void
+fu_cros_ec_usb_device_set_writeable_offset(FuCrosEcUsbDevice *self, guint32 writeable_offset);
+
+void
+fu_cros_ec_usb_device_set_protocol_version(FuCrosEcUsbDevice *self, guint16 protocol_version);
+
+void
+fu_cros_ec_usb_device_set_configuration(FuCrosEcUsbDevice *self, const gchar *configuration);
+
+void
+fu_cros_ec_usb_device_set_in_bootloader(FuCrosEcUsbDevice *self, gboolean in_bootloader);
 
 gboolean
 fu_cros_ec_usb_device_send_subcommand(FuCrosEcUsbDevice *self,
@@ -24,16 +102,72 @@ fu_cros_ec_usb_device_send_subcommand(FuCrosEcUsbDevice *self,
 				      gsize *resp_size,
 				      gboolean allow_less,
 				      GError **error);
+gboolean
+fu_cros_ec_usb_device_transfer_block_cb(FuDevice *device, gpointer user_data, GError **error);
 
 gboolean
 fu_cros_ec_usb_device_start_request_cb(FuDevice *device, gpointer user_data, GError **error);
 
 gboolean
-fu_cros_ec_usb_device_write_touchpad_firmware(FuDevice *device,
-					      FuFirmware *firmware,
-					      FuProgress *progress,
-					      FwupdInstallFlags flags,
-					      FuDevice *tp_device,
-					      GError **error);
+fu_cros_ec_usb_device_probe(FuDevice *device, GError **error);
+
 gboolean
-fu_cros_ec_usb_device_get_in_bootloader(FuDevice *device);
+fu_cros_ec_usb_device_recovery(FuCrosEcUsbDevice *self, GError **error);
+
+gboolean
+fu_cros_ec_usb_device_flush(FuDevice *device, gpointer user_data, GError **error);
+
+gboolean
+fu_cros_ec_usb_device_attach(FuDevice *device, FuProgress *progress, GError **error);
+
+gboolean
+fu_cros_ec_usb_device_detach(FuDevice *device, FuProgress *progress, GError **error);
+
+void
+fu_cros_ec_usb_device_replace(FuDevice *device, FuDevice *donor);
+
+gboolean
+fu_cros_ec_usb_device_cleanup(FuDevice *device,
+			      FuProgress *progress,
+			      FwupdInstallFlags flags,
+			      GError **error);
+
+gboolean
+fu_cros_ec_usb_device_reload(FuDevice *device, GError **error);
+
+void
+fu_cros_ec_usb_device_to_string(FuDevice *device, guint idt, GString *str);
+
+void
+fu_cros_ec_usb_device_set_progress(FuDevice *self, FuProgress *progress);
+
+FuFirmware *
+fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
+				       GInputStream *stream,
+				       FuProgress *progress,
+				       FuFirmwareParseFlags flags,
+				       GError **error);
+
+gboolean
+fu_cros_ec_usb_device_setup(FuDevice *device, GError **error);
+
+void
+fu_cros_ec_usb_device_finalize(GObject *object);
+
+void
+fu_cros_ec_usb_device_send_done(FuCrosEcUsbDevice *self);
+
+gboolean
+fu_cros_ec_usb_device_unlock_rw(FuCrosEcUsbDevice *self, GError **error);
+
+void
+fu_cros_ec_usb_device_reset_to_ro(FuCrosEcUsbDevice *self);
+
+gboolean
+fu_cros_ec_usb_device_transfer_section(FuCrosEcUsbDevice *self,
+				       FuFirmware *firmware,
+				       FuCrosEcFirmwareSection *section,
+				       FuProgress *progress,
+				       GError **error);
+gboolean
+fu_cros_ec_usb_device_stay_in_ro(FuCrosEcUsbDevice *self, GError **error);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.h
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.h
@@ -10,3 +10,13 @@
 
 #define FU_TYPE_CROS_EC_USB_DEVICE (fu_cros_ec_usb_device_get_type())
 G_DECLARE_FINAL_TYPE(FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU, CROS_EC_USB_DEVICE, FuUsbDevice)
+
+gboolean
+fu_cros_ec_usb_device_send_subcommand(FuCrosEcUsbDevice *self,
+				      guint16 subcommand,
+				      guint8 *cmd_body,
+				      gsize body_size,
+				      guint8 *resp,
+				      gsize *resp_size,
+				      gboolean allow_less,
+				      GError **error);

--- a/plugins/cros-ec/fu-cros-ec-usb-hammer.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-hammer.c
@@ -1,0 +1,391 @@
+/*
+ * Copyright 2025 Hamed Elgizery
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#include "fu-cros-ec-common.h"
+#include "fu-cros-ec-firmware.h"
+#include "fu-cros-ec-hammer-touchpad-firmware.h"
+#include "fu-cros-ec-struct.h"
+#include "fu-cros-ec-usb-device.h"
+#include "fu-cros-ec-usb-hammer.h"
+
+struct _FuCrosEcUsbHammer {
+	FuCrosEcUsbDevice parent_instance;
+};
+
+G_DEFINE_TYPE(FuCrosEcUsbHammer, fu_cros_ec_usb_hammer, FU_TYPE_CROS_EC_USB_DEVICE)
+
+typedef struct {
+	FuChunk *block;
+	FuProgress *progress;
+} FuCrosEcUsbBlockHelper;
+
+gboolean
+fu_cros_ec_usb_hammer_write_touchpad_firmware(FuDevice *device,
+					      FuFirmware *firmware,
+					      FuProgress *progress,
+					      FwupdInstallFlags flags,
+					      FuDevice *tp_device,
+					      GError **error)
+{
+	FuCrosEcUsbHammer *self = FU_CROS_EC_USB_HAMMER(device);
+	FuCrosEcHammerTouchpad *touchpad = FU_CROS_EC_HAMMER_TOUCHPAD(tp_device);
+	gsize data_len = 0;
+	guint32 maximum_pdu_size = 0;
+	guint32 tp_fw_size = 0;
+	guint32 tp_fw_address = 0;
+	const guint8 *data_ptr = NULL;
+	g_autoptr(GBytes) img_bytes = NULL;
+	g_autoptr(GPtrArray) blocks = NULL;
+	g_autoptr(FuStructCrosEcFirstResponsePdu) st_rpdu =
+	    fu_struct_cros_ec_first_response_pdu_new();
+
+	/* send start request */
+	if (!fu_device_retry(device,
+			     fu_cros_ec_usb_device_start_request_cb,
+			     FU_CROS_EC_SETUP_RETRY_CNT,
+			     st_rpdu,
+			     error)) {
+		g_prefix_error(error, "touchpad: failed to send start request: ");
+		return FALSE;
+	}
+
+	fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP);
+
+	/*
+	 * Probably, can be replaced with the CrosEcUsbHammer's maximum_pdu_size,
+	 * but opting for independence here.
+	 */
+	maximum_pdu_size = fu_struct_cros_ec_first_response_pdu_get_maximum_pdu_size(st_rpdu);
+	img_bytes = fu_firmware_get_bytes(firmware, error);
+	data_ptr = (const guint8 *)g_bytes_get_data(img_bytes, &data_len);
+	tp_fw_address = fu_cros_ec_hammer_touchpad_get_fw_address(touchpad);
+	tp_fw_size = fu_cros_ec_hammer_touchpad_get_fw_size(touchpad);
+
+	if (tp_fw_address != (1u << 31)) { // This is for testing safety only, should be removed
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "CRITICAL DEVICE ABOUT TO BE BRICKED HALTING");
+		return FALSE;
+	}
+
+	if (data_ptr == NULL || data_len != tp_fw_size) {
+		g_set_error(
+		    error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
+		    "touchpad: image and section sizes do not match: image = %" G_GSIZE_FORMAT
+		    " bytes vs touchpad section size = %" G_GSIZE_FORMAT " bytes",
+		    data_len,
+		    (gsize)tp_fw_size);
+		return FALSE;
+	}
+
+	g_debug("touchpad: sending 0x%x bytes to 0x%x", (guint)data_len, tp_fw_address);
+
+	blocks =
+	    /* send in chunks of PDU size */
+	    fu_chunk_array_new(data_ptr, data_len, tp_fw_address, 0x0, maximum_pdu_size);
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, blocks->len);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
+	for (guint i = 0; i < blocks->len; i++) {
+		FuCrosEcUsbBlockHelper helper = {
+		    .block = g_ptr_array_index(blocks, i),
+		    .progress = fu_progress_get_child(progress),
+		};
+		if (!fu_device_retry(FU_DEVICE(self),
+				     fu_cros_ec_usb_device_transfer_block_cb,
+				     FU_CROS_EC_MAX_BLOCK_XFER_RETRIES,
+				     &helper,
+				     error)) {
+			g_prefix_error(error, "touchpad: failed to transfer block 0x%x: ", i);
+			return FALSE;
+		}
+		fu_progress_step_done(progress);
+	}
+
+	fu_device_remove_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_UPDATING_TP);
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_usb_hammer_write_firmware(FuDevice *device,
+				     FuFirmware *firmware,
+				     FuProgress *progress,
+				     FwupdInstallFlags flags,
+				     GError **error)
+{
+	FuCrosEcUsbHammer *self = FU_CROS_EC_USB_HAMMER(device);
+	g_autoptr(GPtrArray) sections = NULL;
+	FuCrosEcFirmware *cros_ec_firmware = FU_CROS_EC_FIRMWARE(firmware);
+
+	fu_device_remove_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
+
+	if (fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO)) {
+		g_autoptr(FuStructCrosEcFirstResponsePdu) st_rpdu =
+		    fu_struct_cros_ec_first_response_pdu_new();
+
+		fu_device_remove_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO);
+		if (!fu_cros_ec_usb_device_stay_in_ro(FU_CROS_EC_USB_DEVICE(self), error)) {
+			g_prefix_error(error, "failed to send stay-in-ro subcommand: ");
+			return FALSE;
+		}
+
+		/* flush all data from endpoint to recover in case of error */
+		if (!fu_cros_ec_usb_device_recovery(FU_CROS_EC_USB_DEVICE(self), error)) {
+			g_prefix_error(error, "failed to flush device to idle state: ");
+			return FALSE;
+		}
+
+		/* send start request */
+		if (!fu_device_retry(device,
+				     fu_cros_ec_usb_device_start_request_cb,
+				     FU_CROS_EC_SETUP_RETRY_CNT,
+				     st_rpdu,
+				     error)) {
+			g_prefix_error(error, "failed to send start request: ");
+			return FALSE;
+		}
+	}
+
+	if (fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) &&
+	    fu_cros_ec_usb_device_get_in_bootloader(FU_CROS_EC_USB_DEVICE(self))) {
+		/*
+		 * We had previously written to the rw region (while we were
+		 * booted from ro region), but somehow landed in ro again after
+		 * a reboot. Since we wrote rw already, we wanted to jump
+		 * to the new rw so we could evaluate ro.
+		 *
+		 * This is a transitory state due to the fact that we have to
+		 * boot through RO to get to RW. Set another write required to
+		 * allow the RO region to auto-jump to RW.
+		 *
+		 * Special flow: write phase skips actual write -> attach skips
+		 * send of reset command, just sets wait for replug, and
+		 * device restart status.
+		 */
+		fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
+		return TRUE;
+	}
+
+	/*
+	 * If it is turn to update RW section, two conditions need
+	 * to be satisfied:
+	 *   1. ec has to be in bootloader mode
+	 *   2. RW Flash protection has to be disabled (enabled by default).
+	 *
+	 * We set another ANOTHER_WRITE_REQUIRED if any of the conditions is not met.
+	 *
+	 * Proceed with unlocking the the RW flash protection and rebooting
+	 * the device, attempting to land in bootloader mode with RW flash
+	 * protection disabled with the next write attempt.
+	 */
+	if (!fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) &&
+	    (!fu_cros_ec_usb_device_get_in_bootloader(FU_CROS_EC_USB_DEVICE(self)) ||
+	     (fu_cros_ec_usb_device_get_flash_protection(FU_CROS_EC_USB_DEVICE(self)) & (1 << 8)) !=
+		 0)) {
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
+		if (!fu_cros_ec_usb_device_unlock_rw(FU_CROS_EC_USB_DEVICE(self), error))
+			return FALSE;
+		return TRUE;
+	}
+
+	sections = fu_cros_ec_firmware_get_needed_sections(cros_ec_firmware, error);
+	if (sections == NULL)
+		return FALSE;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, sections->len);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
+	for (guint i = 0; i < sections->len; i++) {
+		FuCrosEcFirmwareSection *section = g_ptr_array_index(sections, i);
+		g_autoptr(GError) error_local = NULL;
+
+		if (!fu_cros_ec_usb_device_transfer_section(FU_CROS_EC_USB_DEVICE(self),
+							    firmware,
+							    section,
+							    fu_progress_get_child(progress),
+							    &error_local)) {
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_READ)) {
+				g_debug("failed to transfer section, trying another write, "
+					"ignoring error: %s",
+					error_local->message);
+				fu_device_add_flag(device,
+						   FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
+				fu_progress_finished(progress);
+				return TRUE;
+			}
+			g_propagate_error(error, g_steal_pointer(&error_local));
+			return FALSE;
+		}
+
+		// TODO: Fix me, section->version.triplet has no data...
+		if (fu_cros_ec_usb_device_get_in_bootloader(FU_CROS_EC_USB_DEVICE(self))) {
+			fu_device_set_version(device, section->version.triplet);
+		} else {
+			fu_device_set_version_bootloader(device, section->version.triplet);
+		}
+
+		fu_progress_step_done(progress);
+	}
+
+	/* send done */
+	fu_cros_ec_usb_device_send_done(FU_CROS_EC_USB_DEVICE(self));
+
+	if (fu_cros_ec_usb_device_get_in_bootloader(FU_CROS_EC_USB_DEVICE(self)))
+		fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN);
+	else
+		fu_device_add_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN);
+
+	/* logical XOR */
+	if (fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) !=
+	    fu_device_has_private_flag(device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN))
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_usb_hammer_ensure_children(FuCrosEcUsbHammer *self, GError **error)
+{
+	FuDevice *device = FU_DEVICE(self);
+	g_autoptr(FuCrosEcHammerTouchpad) touchpad = NULL;
+
+	if (!fu_device_has_private_flag(device, FU_CROS_EC_DEVICE_FLAG_HAS_TOUCHPAD))
+		return TRUE;
+
+	touchpad = fu_cros_ec_hammer_touchpad_new(FU_DEVICE(device));
+	fu_device_add_child(FU_DEVICE(device), FU_DEVICE(touchpad));
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_usb_hammer_probe(FuDevice *device, GError **error)
+{
+	if (!fu_cros_ec_usb_device_probe(device, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_usb_hammer_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	if (!fu_cros_ec_usb_device_attach(device, progress, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_usb_hammer_detach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	if (!fu_cros_ec_usb_device_detach(device, progress, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_cros_ec_usb_hammer_replace(FuDevice *device, FuDevice *donor)
+{
+	fu_cros_ec_usb_device_replace(device, donor);
+}
+
+static gboolean
+fu_cros_ec_usb_hammer_cleanup(FuDevice *device,
+			      FuProgress *progress,
+			      FwupdInstallFlags flags,
+			      GError **error)
+{
+	if (!fu_cros_ec_usb_device_cleanup(device, progress, flags, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_usb_hammer_reload(FuDevice *device, GError **error)
+{
+	if (!fu_cros_ec_usb_device_reload(device, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_cros_ec_usb_hammer_to_string(FuDevice *device, guint idt, GString *str)
+{
+	fu_cros_ec_usb_device_to_string(device, idt, str);
+}
+
+static FuFirmware *
+fu_cros_ec_usb_hammer_prepare_firmware(FuDevice *device,
+				       GInputStream *stream,
+				       FuProgress *progress,
+				       FuFirmwareParseFlags flags,
+				       GError **error)
+{
+	return fu_cros_ec_usb_device_prepare_firmware(device, stream, progress, flags, error);
+}
+
+static gboolean
+fu_cros_ec_usb_hammer_setup(FuDevice *device, GError **error)
+{
+	g_warning("HELL YEAH!");
+	if (!fu_cros_ec_usb_device_setup(device, error))
+		return FALSE;
+
+	if (!fu_cros_ec_usb_hammer_ensure_children(FU_CROS_EC_USB_HAMMER(device), error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_cros_ec_usb_hammer_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_cros_ec_usb_device_set_progress(self, progress);
+}
+
+static void
+fu_cros_ec_usb_hammer_init(FuCrosEcUsbHammer *self)
+{
+}
+
+static void
+fu_cros_ec_usb_hammer_class_init(FuCrosEcUsbHammerClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	device_class->attach = fu_cros_ec_usb_hammer_attach;
+	device_class->detach = fu_cros_ec_usb_hammer_detach;
+	device_class->prepare_firmware = fu_cros_ec_usb_hammer_prepare_firmware;
+	device_class->setup = fu_cros_ec_usb_hammer_setup;
+	device_class->to_string = fu_cros_ec_usb_hammer_to_string;
+	device_class->write_firmware = fu_cros_ec_usb_hammer_write_firmware;
+	device_class->probe = fu_cros_ec_usb_hammer_probe;
+	device_class->set_progress = fu_cros_ec_usb_hammer_set_progress;
+	device_class->reload = fu_cros_ec_usb_hammer_reload;
+	device_class->replace = fu_cros_ec_usb_hammer_replace;
+	device_class->cleanup = fu_cros_ec_usb_hammer_cleanup;
+}

--- a/plugins/cros-ec/fu-cros-ec-usb-hammer.h
+++ b/plugins/cros-ec/fu-cros-ec-usb-hammer.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Hamed Elgizery
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#include "fu-cros-ec-hammer-touchpad.h"
+#include "fu-cros-ec-usb-device.h"
+
+#define FU_TYPE_CROS_EC_USB_HAMMER (fu_cros_ec_usb_hammer_get_type())
+G_DECLARE_FINAL_TYPE(FuCrosEcUsbHammer,
+		     fu_cros_ec_usb_hammer,
+		     FU,
+		     CROS_EC_USB_HAMMER,
+		     FuCrosEcUsbDevice)
+
+gboolean
+fu_cros_ec_usb_hammer_write_touchpad_firmware(FuDevice *device,
+					      FuFirmware *firmware,
+					      FuProgress *progress,
+					      FwupdInstallFlags flags,
+					      FuDevice *tp_device,
+					      GError **error);

--- a/plugins/cros-ec/fu-cros-ec.rs
+++ b/plugins/cros-ec/fu-cros-ec.rs
@@ -80,7 +80,7 @@ struct FuStructCrosEcTouchpadGetInfoResponsePdu {
     vendor: u16le,                  // Vendor USB id
     fw_address: u32le,              // Virtual address to touchpad firmware
     fw_size: u32le,                 // Size of the touchpad firmware
-    allowed_fw_hash: [u8le; 32],    // Checksum of the entire touchpad firmware accepted by the EC image
+    allowed_fw_hash: [u8; 32],    // Checksum of the entire touchpad firmware accepted by the EC image
     id: u16le,
     fw_version: u16le,
     fw_checksum: u16le,

--- a/plugins/cros-ec/fu-cros-ec.rs
+++ b/plugins/cros-ec/fu-cros-ec.rs
@@ -80,7 +80,7 @@ struct FuStructCrosEcTouchpadGetInfoResponsePdu {
     vendor: u16le,                  // Vendor USB id
     fw_address: u32le,              // Virtual address to touchpad firmware
     fw_size: u32le,                 // Size of the touchpad firmware
-    allowed_fw_hash: [char; 32],    // Checksum of the entire touchpad firmware accepted by the EC image
+    allowed_fw_hash: [u8le; 32],    // Checksum of the entire touchpad firmware accepted by the EC image
     id: u16le,
     fw_version: u16le,
     fw_checksum: u16le,

--- a/plugins/cros-ec/fu-cros-ec.rs
+++ b/plugins/cros-ec/fu-cros-ec.rs
@@ -68,6 +68,20 @@ struct FuStructCrosEcFirstResponsePdu {
     flash_protection: u32be,    // status
     offset: u32be,              // offset of the other region
     version: [char; 32],        // version string of the other region
-    _min_rollback: u32be,        // minimum rollback version that RO will accept
-    _key_version: u32be,         // RO public key version
+    _min_rollback: u32be,       // minimum rollback version that RO will accept
+    _key_version: u32be,        // RO public key version
+}
+
+#[derive(New, Getters)]
+#[repr(C, packed)]
+struct FuStructCrosEcTouchpadGetInfoResponsePdu {
+    status: u8le,                   // Indicate if we get info from touchpad
+    reserved: u8le,                 //Reserved for padding
+    vendor: u16le,                  // Vendor USB id
+    fw_address: u32le,              // Virtual address to touchpad firmware
+    fw_size: u32le,                 // Size of the touchpad firmware
+    allowed_fw_hash: [char; 32],    // Checksum of the entire touchpad firmware accepted by the EC image
+    id: u16le,
+    fw_version: u16le,
+    fw_checksum: u16le,
 }

--- a/plugins/cros-ec/fu-cros-ec.rs
+++ b/plugins/cros-ec/fu-cros-ec.rs
@@ -37,7 +37,7 @@ enum FuCrosEcFirmwareUpgradeStatus {
 #[repr(C, packed)]
 struct FuStructCrosEcUpdateFrameHeader {
     block_size: u32be,          // total frame size, including this field
-    _cmd_block_digest: u32be,    // four bytes of the structure sha1 digest (or 0 where ignored)
+    cmd_block_digest: u32be,    // first four bytes of the structure sha256 digest (or 0 where ignored)
     cmd_block_base: u32be,      // offset of this PDU into the flash SPI
     // payload goes here
 }

--- a/plugins/cros-ec/meson.build
+++ b/plugins/cros-ec/meson.build
@@ -9,6 +9,7 @@ plugin_builtins += static_library('fu_plugin_cros_ec',
   sources: [
     'fu-cros-ec-plugin.c',
     'fu-cros-ec-usb-device.c',
+    'fu-cros-ec-usb-hammer.c',
     'fu-cros-ec-hammer-touchpad.c',
     'fu-cros-ec-hammer-touchpad-firmware.c',
     'fu-cros-ec-common.c',      # fuzzing

--- a/plugins/cros-ec/meson.build
+++ b/plugins/cros-ec/meson.build
@@ -9,6 +9,7 @@ plugin_builtins += static_library('fu_plugin_cros_ec',
   sources: [
     'fu-cros-ec-plugin.c',
     'fu-cros-ec-usb-device.c',
+    'fu-cros-ec-hammer-touchpad.c',
     'fu-cros-ec-common.c',      # fuzzing
     'fu-cros-ec-firmware.c',    # fuzzing
   ],
@@ -18,6 +19,7 @@ plugin_builtins += static_library('fu_plugin_cros_ec',
   dependencies: plugin_deps,
 )
 
+#TODO: Add test for hammer
 device_tests += files(
   'tests/acer-d501.json',
   'tests/google-servo-micro.json',

--- a/plugins/cros-ec/meson.build
+++ b/plugins/cros-ec/meson.build
@@ -10,6 +10,7 @@ plugin_builtins += static_library('fu_plugin_cros_ec',
     'fu-cros-ec-plugin.c',
     'fu-cros-ec-usb-device.c',
     'fu-cros-ec-hammer-touchpad.c',
+    'fu-cros-ec-hammer-touchpad-firmware.c',
     'fu-cros-ec-common.c',      # fuzzing
     'fu-cros-ec-firmware.c',    # fuzzing
   ],


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Instead of integrating the hammer specific update flow requirements within the stable tested update flow of cros-ec, this separates the logic of Hammer by subclassing the existing FuCrosEcUsbDevice class, and relying on the exact same vfuncs but with modifying the write_firmware method.

This is a more thoughtful approach of other devices, as fwupd will still use the original code for the other devices (the ones that cros-ec already keeps in mind), and fwupd will use the new FuCrosEcUsbHammer class for updating the hammer device, so we don't need to worry about breaking things for other devices.

This also allows for more flexibility later, when we decide to implement more of the Hammerd specific flows e.g. injecting entropy. Also, adopting this pattern of subclassing now will help when we later add support to i2c ec devices, and i2c Hammer devices.

I followed a pattern similar to that of https://github.com/fwupd/fwupd/blob/f255de76386cf2ddd464394a9231a1705e09fd64/plugins/pixart-rf/pixart-rf.quirk