### PR TITLE
cros-ec: read RO public key version and minimum rollback from FMAP

### DIFF
--- a/plugins/cros-ec/fu-cros-ec-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-firmware.c
@@ -78,11 +78,20 @@ fu_cros_ec_firmware_ensure_version(FuCrosEcFirmware *self, GError **error)
 		FuCrosEcFirmwareSection *section = g_ptr_array_index(self->sections, i);
 		const gchar *fmap_name;
 		const gchar *fmap_fwid_name;
+		const gchar *fmap_rollback_name;
+		const gchar *fmap_key_name;
 		g_autoptr(FuCrosEcVersion) version = NULL;
 		g_autoptr(FuFirmware) img = NULL;
+		g_autoptr(FuFirmware) img_version = NULL;
 		g_autoptr(FuFirmware) fwid_img = NULL;
+		g_autoptr(FuFirmware) rbver_img = NULL;
+		g_autoptr(FuFirmware) key_img = NULL;
 		g_autoptr(GBytes) payload_bytes = NULL;
 		g_autoptr(GBytes) fwid_bytes = NULL;
+		g_autoptr(GBytes) rbver_bytes = NULL;
+		g_autoptr(GBytes) key_bytes = NULL;
+		g_autoptr(FuStructCrosEcVb21PackedKey) st_vb21_packed_key =
+		    fu_struct_cros_ec_vb21_packed_key_new();
 
 		if (g_strcmp0(section->name, "RO") == 0) {
 			fmap_name = "EC_RO";
@@ -91,6 +100,11 @@ fu_cros_ec_firmware_ensure_version(FuCrosEcFirmware *self, GError **error)
 			rw = TRUE;
 			fmap_name = "EC_RW";
 			fmap_fwid_name = "RW_FWID";
+			fmap_rollback_name = "RW_RBVER";
+			/* key version comes from key RO, RW signature
+			 * does not contain the key version
+			 */
+			fmap_key_name = "KEY_RO";
 		} else {
 			g_set_error_literal(error,
 					    FWUPD_ERROR,
@@ -153,6 +167,61 @@ fu_cros_ec_firmware_ensure_version(FuCrosEcFirmware *self, GError **error)
 				return FALSE;
 			}
 			fu_firmware_set_version(FU_FIRMWARE(self), version_rw->triplet);
+
+			/* failure is okay, means firmware has no rollback section */
+			rbver_img = fu_firmware_get_image_by_id(FU_FIRMWARE(self),
+								fmap_rollback_name,
+								NULL);
+			if (rbver_img == NULL) {
+				g_info("%s image not found: ", fmap_rollback_name);
+				section->rollback = -1;
+			} else {
+				rbver_bytes = fu_firmware_write(rbver_img, error);
+				if (rbver_bytes == NULL) {
+					g_prefix_error(error,
+						       "unable to get bytes from %s: ",
+						       fmap_rollback_name);
+					return FALSE;
+				}
+				if (!fu_memcpy_safe((guint8 *)&section->rollback,
+						    sizeof(section->rollback),
+						    0x0,
+						    g_bytes_get_data(rbver_bytes, NULL),
+						    g_bytes_get_size(rbver_bytes),
+						    0x0,
+						    sizeof(section->rollback),
+						    error))
+					return FALSE;
+			}
+
+			/* failure is okay, means firmware has no key version section */
+			key_img =
+			    fu_firmware_get_image_by_id(FU_FIRMWARE(self), fmap_key_name, NULL);
+			if (key_img == NULL) {
+				g_info("%s image not found: ", fmap_key_name);
+				section->key_version = -1;
+			} else {
+				key_bytes = fu_firmware_write(key_img, error);
+				if (key_bytes == NULL) {
+					g_prefix_error(error,
+						       "unable to get bytes from %s: ",
+						       fmap_key_name);
+					return FALSE;
+				}
+				if (!fu_memcpy_safe((guint8 *)st_vb21_packed_key->buf->data,
+						    st_vb21_packed_key->buf->len,
+						    0x0,
+						    g_bytes_get_data(key_bytes, NULL),
+						    g_bytes_get_size(key_bytes),
+						    0x0,
+						    st_vb21_packed_key->buf->len,
+						    error))
+					return FALSE;
+
+				section->key_version =
+				    fu_struct_cros_ec_vb21_packed_key_get_key_version(
+					st_vb21_packed_key);
+			}
 		}
 	}
 

--- a/plugins/cros-ec/fu-cros-ec-firmware.h
+++ b/plugins/cros-ec/fu-cros-ec-firmware.h
@@ -21,7 +21,7 @@ typedef struct {
 	FuCrosEcFirmwareUpgradeStatus ustatus;
 	gchar raw_version[FU_FMAP_FIRMWARE_STRLEN];
 	FuCrosEcVersion version;
-	gint32 rollback;
+	guint32 rollback;
 	guint32 key_version;
 	guint64 image_idx;
 } FuCrosEcFirmwareSection;

--- a/plugins/cros-ec/fu-cros-ec.rs
+++ b/plugins/cros-ec/fu-cros-ec.rs
@@ -68,6 +68,32 @@ struct FuStructCrosEcFirstResponsePdu {
     flash_protection: u32be,    // status
     offset: u32be,              // offset of the other region
     version: [char; 32],        // version string of the other region
-    _min_rollback: u32be,        // minimum rollback version that RO will accept
-    _key_version: u32be,         // RO public key version
+    min_rollback: u32be,       // minimum rollback version that RO will accept
+    key_version: u32be,        // RO public key version
+}
+
+#[repr(C, packed)]
+struct FuStructCrosEcVb2Id {
+    raw: [u8; 20],
+
+#[repr(C, packed)]
+struct FuStructCrosEcVb21StructCommon {
+    magic: u32le,
+    struct_version_major: u16le,
+    struct_version_minor: u16le,
+    total_size: u32le,
+    fixed_size: u32le,
+    desc_size: u32le,
+}
+
+#[derive(New, Getters)]
+#[repr(C, packed)]
+struct FuStructCrosEcVb21PackedKey {
+    c: FuStructCrosEcVb21StructCommon,
+    key_offset: u32le,
+    key_size: u32le,
+    sig_alg: u16le,
+    hash_alg: u16le,
+    key_version: u32le,
+    id: FuStructCrosEcVb2Id,
 }


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

The key version will be used as a gatekeeper, to verify compatibility of the RO section with the new firmware, before actually updating.

[1] https://source.chromium.org/chromiumos/chromiumos/codesearch/+/main:src/platform2/hammerd/update_fw.cc;l=258?q=key%20version&ss=chromiumos%2Fchromiumos%2Fcodesearch:src%2Fplatform2%2Fhammerd%2F  